### PR TITLE
Added Geonames provider for Geocoding

### DIFF
--- a/packages/geocoding/lib/index.ts
+++ b/packages/geocoding/lib/index.ts
@@ -1,1 +1,2 @@
 export * from "./providers";
+export * from "./model";

--- a/packages/geocoding/lib/providers/geoadmin.provider.ts
+++ b/packages/geocoding/lib/providers/geoadmin.provider.ts
@@ -78,12 +78,6 @@ export function queryGeoadmin(
     );
 }
 
-export function sayHello() {
-  console.log("hello")
-  return "hello";
-}
-
-
 function bboxToGeometry(extent: BBox): Geometry {
   const [minX, minY, maxX, maxY] = extent;
   return {

--- a/packages/geocoding/lib/providers/geonames.provider.test.ts
+++ b/packages/geocoding/lib/providers/geonames.provider.test.ts
@@ -1,0 +1,129 @@
+import {queryGeonames} from "./geonames.provider";
+import { GeocodingResult } from "../model";
+import {describe} from "vitest";
+
+const MOCK_DATA = {
+    totalResultsCount: 35,
+    geonames: [
+        {
+            adminCode1: "ZH",
+            lng: "8.55",
+            geonameId: 2657896,
+            toponymName: "Zürich",
+            countryId: "2658434",
+            fcl: "P",
+            population: 341730,
+            countryCode: "CH",
+            name: "Zurich",
+            fclName: "city, village...",
+            adminCodes1: { ISO3166_2: "ZH" },
+            countryName: "Switzerland",
+            fcodeName: "seat of a first-order administrative division",
+            adminName1: "Zurich",
+            lat: "47.36667",
+            fcode: "PPLA"
+        },
+        {
+            adminCode1: "ZH",
+            lng: "8.66667",
+            geonameId: 2657895,
+            toponymName: "Kanton Zürich",
+            countryId: "2658434",
+            fcl: "A",
+            population: 1553423,
+            countryCode: "CH",
+            name: "Zurich",
+            fclName: "country, state, region...",
+            adminCodes1: { ISO3166_2: "ZH" },
+            countryName: "Switzerland",
+            fcodeName: "first-order administrative division",
+            adminName1: "Zurich",
+            lat: "47.41667",
+            fcode: "ADM1"
+        }
+    ]
+};
+
+vi.stubGlobal('fetch', vi.fn(() =>
+    Promise.resolve({
+        ok: true, // Ensure the mock reflects a successful response
+        json: () => Promise.resolve(MOCK_DATA),
+    }) as unknown as Response
+));
+
+
+describe("queryGeonames", () => {
+    let results: GeocodingResult[];
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe("results parsing", () => {
+        beforeEach(async () => {
+            results = await queryGeonames("Zurich");
+        });
+        it("correctly processes Geonames API response", () => {
+            expect(results).toEqual([
+                {
+                    label: "Zurich",
+                    geom: {
+                        type: "Point",
+                        coordinates: [8.55, 47.36667],
+                    },
+                },
+                {
+                    label: "Zurich",
+                    geom: {
+                        type: "Point",
+                        coordinates: [8.66667, 47.41667],
+                    },
+                },
+            ]);
+        });
+    });
+    describe("default options", () => {
+        beforeEach(async () => {
+            results = await queryGeonames("Zurich");
+        });
+        it("uses default options", () => {
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining("https://secure.geonames.org/searchJSON?q=Zurich&username=gn_ui&maxRows=10")
+            );
+        });
+    });
+
+    describe("custom options", () => {
+        beforeEach(async () => {
+            results = await queryGeonames("Zurich", {
+                lang: "de",
+                maxRows: 5,
+                country: "CH",
+                username: "customUser",
+            });
+        });
+        it("uses given options for custom search", () => {
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining("https://secure.geonames.org/searchJSON?q=Zurich&username=customUser&maxRows=5&country=CH&lang=de&style=FULL&type=json")
+            );
+        });
+    });
+
+    describe("bounding box search", () => {
+        beforeEach(async () => {
+            results = await queryGeonames("Zurich", {
+                east: 10,
+                west: 5,
+                north: 50,
+                south: 45,
+                username: "customUser",
+            });
+        });
+        it("uses given options for bounding box search", () => {
+            expect(global.fetch).toHaveBeenCalledWith(
+                expect.stringContaining("https://secure.geonames.org/searchJSON?q=Zurich&username=customUser&maxRows=10&lang=en&style=FULL&type=json&east=10&west=5&north=50&south=45")
+            );
+        });
+    });
+
+});

--- a/packages/geocoding/lib/providers/geonames.provider.ts
+++ b/packages/geocoding/lib/providers/geonames.provider.ts
@@ -5,7 +5,7 @@ const baseUrl = "https://secure.geonames.org/searchJSON";
 
 /**
  * Reference documentation: http://www.geonames.org/export/geonames-search.html
- * @property lang Place name and country name will be returned in the specified language. Default is English.
+ * @property lang Default is English. Either "local" or iso2 country code should be used
  * @property maxRows The maximal number of rows in the document returned by the service. Default is 100
  * @property country Default is all countries. The country parameter may occur more than once, example: country=FR&country=GP
  * @property style verbosity of returned xml document, default = MEDIUM
@@ -15,11 +15,10 @@ const baseUrl = "https://secure.geonames.org/searchJSON";
  */
 
 export interface GeonamesOptions {
-    lang?: "de" | "fr" | "it" | "rm" | "en";
+    lang?: string;
     maxRows?: number;
     country?: string | string[]; // Now supports multiple countries
     style?: "SHORT" | "MEDIUM" | "LONG" | "FULL";
-    type?: "json" | "xml" | "rdf";
     username: string;
     east?: number;
     west?: number;
@@ -45,7 +44,6 @@ export function queryGeonames(
         lang: "en",
         maxRows: 10,
         style: "FULL",
-        type: "json",
         username: "gn_ui",
     };
 
@@ -62,7 +60,7 @@ export function queryGeonames(
     }
     finalOptions.lang && url.searchParams.set("lang", finalOptions.lang);
     finalOptions.style && url.searchParams.set("style", finalOptions.style);
-    finalOptions.type && url.searchParams.set("type", finalOptions.type);
+    url.searchParams.set("type", "json");
 
     if (finalOptions.east !== undefined && finalOptions.west !== undefined &&
         finalOptions.north !== undefined && finalOptions.south !== undefined &&

--- a/packages/geocoding/lib/providers/geonames.provider.ts
+++ b/packages/geocoding/lib/providers/geonames.provider.ts
@@ -1,0 +1,95 @@
+import { GeocodingResult } from "../model";
+import { Geometry } from "geojson";
+
+const baseUrl = "https://secure.geonames.org/searchJSON";
+
+/**
+ * Reference documentation: http://www.geonames.org/export/geonames-search.html
+ * @property lang Place name and country name will be returned in the specified language. Default is English.
+ * @property maxRows The maximal number of rows in the document returned by the service. Default is 100
+ * @property country Default is all countries. The country parameter may occur more than once, example: country=FR&country=GP
+ * @property style verbosity of returned xml document, default = MEDIUM
+ * @property type The format type of the returned document, default = xml
+ * @property username The parameter 'username' needs to be passed with each request. (https://www.geonames.org/login)
+ * @property east, west, north, south Restrict the search to the given bounding box
+ */
+
+export interface GeonamesOptions {
+    lang?: "de" | "fr" | "it" | "rm" | "en";
+    maxRows?: number;
+    country?: string | string[]; // Now supports multiple countries
+    style?: "SHORT" | "MEDIUM" | "LONG" | "FULL";
+    type?: "json" | "xml" | "rdf";
+    username: string;
+    east?: number;
+    west?: number;
+    north?: number;
+    south?: number;
+}
+
+interface GeonameResponse {
+    name: string;
+    lng: string;
+    lat: string;
+}
+
+export function queryGeonames(
+    input: string,
+    options?: GeonamesOptions,
+): Promise<GeocodingResult[]> {
+    if (!input.trim()) {
+        throw new Error("Input query is required and cannot be empty.");
+    }
+
+    const baseOptions: GeonamesOptions = {
+        lang: "en",
+        maxRows: 10,
+        style: "FULL",
+        type: "json",
+        username: "gn_ui",
+    };
+
+    const finalOptions = { ...baseOptions, ...options };
+
+    const url = new URL(baseUrl);
+    url.searchParams.set("q", input.trim());
+    url.searchParams.set("username", finalOptions.username);
+    finalOptions.maxRows && url.searchParams.set("maxRows", finalOptions.maxRows.toString());
+    if (typeof finalOptions.country === "string") {
+        url.searchParams.set("country", finalOptions.country);
+    } else if (Array.isArray(finalOptions.country)) {
+        finalOptions.country.forEach(c => url.searchParams.append("country", c));
+    }
+    finalOptions.lang && url.searchParams.set("lang", finalOptions.lang);
+    finalOptions.style && url.searchParams.set("style", finalOptions.style);
+    finalOptions.type && url.searchParams.set("type", finalOptions.type);
+
+    if (finalOptions.east !== undefined && finalOptions.west !== undefined &&
+        finalOptions.north !== undefined && finalOptions.south !== undefined &&
+        finalOptions.east > finalOptions.west && finalOptions.north > finalOptions.south) {
+        url.searchParams.set("east", finalOptions.east.toString());
+        url.searchParams.set("west", finalOptions.west.toString());
+        url.searchParams.set("north", finalOptions.north.toString());
+        url.searchParams.set("south", finalOptions.south.toString());
+    }
+
+    return fetch(url.toString())
+        .then(response => {
+            if (!response.ok) {
+                throw new Error(`Geonames API returned ${response.status}: ${response.statusText}`);
+            }
+            return response.json();
+        })
+        .then((data: { geonames: GeonameResponse[] }) => {
+            if (!data.geonames) {
+                throw new Error('Invalid response from Geonames API: no geonames property');
+            }
+            return data.geonames.map(geoname => ({
+                label: geoname.name,
+                geom: {
+                    type: "Point",
+                    coordinates: [parseFloat(geoname.lng), parseFloat(geoname.lat)],
+                } as Geometry,
+            }));
+        });
+}

--- a/packages/geocoding/lib/providers/index.ts
+++ b/packages/geocoding/lib/providers/index.ts
@@ -1,2 +1,3 @@
 export * from "./geoadmin.provider";
 export * from "./data-gouv-fr.provider";
+export * from "./geonames.provider";


### PR DESCRIPTION
This pull request introduces the **Geonames** provider to our geocoding service. The Geonames provider is implemented in the `geonames.provider.ts` file and it includes the `queryGeonames` function which is used to fetch geocoding data from the Geonames API.

In addition to this, I am also exporting the `GeocodingResult` model so that we can it as a type while consuming the SDK.