### PR TITLE
Fix running of example app

### DIFF
--- a/apps/examples/package-lock.json
+++ b/apps/examples/package-lock.json
@@ -36,12 +36,15 @@
         "vue-tsc": "^1.8.25"
       }
     },
+    "../../packages/geocoding/dist": {
+      "extraneous": true
+    },
     "../../packages/openlayers": {
       "name": "@geospatial-sdk/openlayers",
-      "version": "0.0.5-alpha.1",
+      "version": "0.0.5-alpha.2",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@geospatial-sdk/core": "^0.0.5-alpha.1",
+        "@geospatial-sdk/core": "^0.0.5-alpha.2",
         "chroma-js": "^2.4.2"
       },
       "devDependencies": {
@@ -51,6 +54,9 @@
       "peerDependencies": {
         "ol": ">6.x"
       }
+    },
+    "../../packages/openlayers/dist": {
+      "extraneous": true
     },
     "node_modules/@aashutoshrathi/word-wrap": {
       "version": "1.2.6",

--- a/apps/examples/vite.config.ts
+++ b/apps/examples/vite.config.ts
@@ -1,7 +1,6 @@
-import { fileURLToPath, URL } from 'node:url'
-
-import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+import vue from '@vitejs/plugin-vue';
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -10,7 +9,13 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      '@': fileURLToPath(new URL('./src', import.meta.url))
+      '@': fileURLToPath(new URL('./src', import.meta.url)),
+      '@geospatial-sdk/geocoding': fileURLToPath(new URL('../../packages/geocoding/dist', import.meta.url)),
+      '@geospatial-sdk/openlayers': fileURLToPath(new URL('../../packages/openlayers/dist', import.meta.url))
     }
+  },
+  optimizeDeps: {
+    include: ['@geospatial-sdk/geocoding', '@geospatial-sdk/openlayers'],
+    exclude: []
   }
-})
+});


### PR DESCRIPTION
This PR adds necessary configurations to the `vite.config.ts` file of the example app to resolve import errors related to the `@geospatial-sdk/geocoding` and `@geospatial-sdk/openlayers` packages. 