### PR TITLE
Added support for ogc-api

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@camptocamp/ogc-client": "^1.1.1-dev.02b9b14",
         "@geospatial-sdk/core": "*"
       },
       "devDependencies": {
@@ -2203,6 +2204,27 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@camptocamp/ogc-client": {
+      "version": "1.1.1-dev.ea89a7b",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.1.1-dev.ea89a7b.tgz",
+      "integrity": "sha512-rtUl9LF6+Q70yec+XKCZKTkP6B1AfOTm/mRvI/f1aRJr1VC8nH4J8fG5OufQon60Fx1OVsuWxtnhfXoGV+5xtw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@rgrove/parse-xml": "^4.1.0"
+      },
+      "peerDependencies": {
+        "ol": ">5.x",
+        "proj4": ">2.8"
+      },
+      "peerDependenciesMeta": {
+        "ol": {
+          "optional": true
+        },
+        "proj4": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@docsearch/css": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.5.2.tgz",
@@ -3549,7 +3571,7 @@
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.4.tgz",
       "integrity": "sha512-kB+NJ5Br56ZhElKsf0pM7/PQfrDdDVMRz8f0JM6eVOGE+L89z9hwcst9QvWBBnazzuqGTGtPsJNZoQ1JdNiGSQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3559,6 +3581,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@rgrove/parse-xml": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/@rgrove/parse-xml/-/parse-xml-4.1.0.tgz",
+      "integrity": "sha512-pBiltENdy8SfI0AeR1e5TRpS9/9Gl0eiOEt6ful2jQfzsgvZYWqsKiBWaOCLdocQuk0wS7KOHI37n0C1pnKqTw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
@@ -5625,13 +5656,13 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/color-parse": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.0.tgz",
       "integrity": "sha512-g2Z+QnWsdHLppAbrpcFWo629kLOnOPtpxYV69GCqm92gqSgyXbzlfyN3MXs0412fPBkFmiuS+rXposgBgBa6Kg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -5640,7 +5671,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
       "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-parse": "^2.0.0",
         "color-space": "^2.0.0"
@@ -5650,7 +5681,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
       "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -6254,7 +6285,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -7169,7 +7200,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.1.tgz",
       "integrity": "sha512-Ss6HQEhrlR2v0FmOGq88l0wa2oCmmGi6rXAMiUxR/T7Xe98evypEmyiji7lvVeVR/AXuxK0xDCWcwfWkSmOrAA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
@@ -7188,7 +7219,7 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
       "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=12"
       },
@@ -7658,7 +7689,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
+      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -8423,7 +8454,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
       "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/lerna": {
       "version": "8.0.2",
@@ -10029,7 +10060,7 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/ol/-/ol-8.2.0.tgz",
       "integrity": "sha512-/m1ddd7Jsp4Kbg+l7+ozR5aKHAZNQOBAoNZ5pM9Jvh4Etkf0WGkXr9qXd7PnhmwiC1Hnc2Toz9XjCzBBvexfXw==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "color-rgba": "^3.0.0",
         "color-space": "^2.0.1",
@@ -10557,7 +10588,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
       "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -10575,7 +10606,7 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
       "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -10717,7 +10748,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -10930,7 +10961,7 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/protocols": {
       "version": "2.0.1",
@@ -10998,13 +11029,13 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/rbush": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "quickselect": "^2.0.0"
       }
@@ -11501,7 +11532,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -13547,7 +13578,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
       "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -13823,7 +13854,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
       "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -13898,7 +13929,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
       "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
-      "dev": true
+      "devOptional": true
     },
     "packages/core": {
       "name": "@geospatial-sdk/core",

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@camptocamp/ogc-client": "^1.1.1-dev.02b9b14",
+        "@camptocamp/ogc-client": "^1.1.1-dev.a9abcef",
         "@geospatial-sdk/core": "*"
       },
       "devDependencies": {
@@ -2205,12 +2205,12 @@
       }
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.1.1-dev.ea89a7b",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.1.1-dev.ea89a7b.tgz",
-      "integrity": "sha512-rtUl9LF6+Q70yec+XKCZKTkP6B1AfOTm/mRvI/f1aRJr1VC8nH4J8fG5OufQon60Fx1OVsuWxtnhfXoGV+5xtw==",
-      "license": "BSD-3-Clause",
+      "version": "1.1.1-dev.a9abcef",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.1.1-dev.a9abcef.tgz",
+      "integrity": "sha512-tChHgEcvs1ZroAA/MC6Y2QAfZSn/XVYOTZ25x5LOeqhT4oxeeS489cVgTmprgNzGw6y0/fsdyh0DVeFYp/kxsw==",
       "dependencies": {
-        "@rgrove/parse-xml": "^4.1.0"
+        "@rgrove/parse-xml": "^4.1.0",
+        "node-fetch": "^3.3.1"
       },
       "peerDependencies": {
         "ol": ">5.x",
@@ -2223,6 +2223,23 @@
         "proj4": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@camptocamp/ogc-client/node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/@docsearch/css": {
@@ -6017,6 +6034,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/data-urls": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
@@ -6872,6 +6897,28 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/figures": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-3.2.0.tgz",
@@ -7099,6 +7146,17 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fs-constants": {
@@ -9412,6 +9470,24 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.7",
@@ -13572,6 +13648,14 @@
       "dev": true,
       "dependencies": {
         "defaults": "^1.0.3"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "engines": {
+        "node": ">= 8"
       }
     },
     "node_modules/web-worker": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
-        "@camptocamp/ogc-client": "^1.1.1-dev.a9abcef",
+        "@camptocamp/ogc-client": "1.1.1-dev.9671ef4",
         "@geospatial-sdk/core": "*"
       },
       "devDependencies": {
@@ -2205,9 +2205,10 @@
       }
     },
     "node_modules/@camptocamp/ogc-client": {
-      "version": "1.1.1-dev.a9abcef",
-      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.1.1-dev.a9abcef.tgz",
-      "integrity": "sha512-tChHgEcvs1ZroAA/MC6Y2QAfZSn/XVYOTZ25x5LOeqhT4oxeeS489cVgTmprgNzGw6y0/fsdyh0DVeFYp/kxsw==",
+      "version": "1.1.1-dev.9671ef4",
+      "resolved": "https://registry.npmjs.org/@camptocamp/ogc-client/-/ogc-client-1.1.1-dev.9671ef4.tgz",
+      "integrity": "sha512-B7E3D11AnGjbXyuwgo1+E2aoMSTry+hoNzGESqL3CQPUdZfM5F4EUp5zJO5/FrEqwsKV5pN3VueOed1jd4MN7w==",
+      "license": "BSD-3-Clause",
       "dependencies": {
         "@rgrove/parse-xml": "^4.1.0",
         "node-fetch": "^3.3.1"

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@camptocamp/ogc-client": "^1.1.1-dev.a9abcef",
+    "@camptocamp/ogc-client": "1.1.1-dev.9671ef4",
     "@geospatial-sdk/core": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
+    "@camptocamp/ogc-client": "^1.1.1-dev.02b9b14",
     "@geospatial-sdk/core": "*"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "@camptocamp/ogc-client": "^1.1.1-dev.02b9b14",
+    "@camptocamp/ogc-client": "^1.1.1-dev.a9abcef",
     "@geospatial-sdk/core": "*"
   }
 }

--- a/packages/core/fixtures/map-context.fixtures.ts
+++ b/packages/core/fixtures/map-context.fixtures.ts
@@ -37,8 +37,7 @@ export const MAP_CTX_LAYER_WFS_FIXTURE: MapContextLayerWfs = deepFreeze({
 export const MAP_CTX_LAYER_OGCAPI_FIXTURE: MapContextLayerOgcApi = deepFreeze({
     type: "ogcapi",
     url: "https://demo.ldproxy.net/zoomstack/collections/airports/items?f=json",
-    layerType: "feature",
-    name: "airports",
+    collection: "airports",
 });
 export const MAP_CTX_LAYER_GEOJSON_FIXTURE: MapContextLayerGeojson =
   deepFreeze<MapContextLayerGeojson>({

--- a/packages/core/fixtures/map-context.fixtures.ts
+++ b/packages/core/fixtures/map-context.fixtures.ts
@@ -8,6 +8,7 @@ import {
   MapContextLayerWms,
   MapContextLayerXyz,
   MapContextView,
+  MapContextLayerOgcApi,
 } from "../lib/model";
 import { deepFreeze } from "../lib/utils";
 
@@ -32,6 +33,12 @@ export const MAP_CTX_LAYER_WFS_FIXTURE: MapContextLayerWfs = deepFreeze({
   visibility: true,
   attributions: "camptocamp",
   opacity: 0.5,
+});
+export const MAP_CTX_LAYER_OGCAPI_FIXTURE: MapContextLayerOgcApi = deepFreeze({
+    type: "ogcapi",
+    url: "https://demo.ldproxy.net/zoomstack/collections/airports/items?f=json",
+    layerType: "feature",
+    name: "airports",
 });
 export const MAP_CTX_LAYER_GEOJSON_FIXTURE: MapContextLayerGeojson =
   deepFreeze<MapContextLayerGeojson>({

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -1,4 +1,4 @@
-import exp from "constants";
+
 import { FeatureCollection, Geometry } from "geojson";
 
 export type LayerDimensions = Record<string, string>;
@@ -46,8 +46,10 @@ export interface MapContextLayerWfs extends MapContextBaseLayer {
 export interface MapContextLayerOgcApi extends MapContextBaseLayer{
   type: 'ogcapi'
   url: string
-  name: string
-  layerType: 'feature' | 'vectorTiles' | 'mapTiles' | 'record'
+  collection: string
+  useTiles?: 'vector' | 'map'
+  tileMatrixSet?: string
+  options?: Record<string, string>
 }
 
 export interface MapContextLayerXyz extends MapContextBaseLayer {

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -40,7 +40,7 @@ export interface MapContextLayerWmts extends MapContextBaseLayer {
 export interface MapContextLayerWfs extends MapContextBaseLayer {
   type: "wfs";
   url: string;
-  featureType: string;
+  name: string;
 }
 
 export interface MapContextLayerOgcApi extends MapContextBaseLayer{

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -40,7 +40,7 @@ export interface MapContextLayerWmts extends MapContextBaseLayer {
 export interface MapContextLayerWfs extends MapContextBaseLayer {
   type: "wfs";
   url: string;
-  name: string;
+  featureType: string;
 }
 
 export interface MapContextLayerOgcApi extends MapContextBaseLayer{

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -1,3 +1,4 @@
+import exp from "constants";
 import { FeatureCollection, Geometry } from "geojson";
 
 export type LayerDimensions = Record<string, string>;
@@ -42,6 +43,13 @@ export interface MapContextLayerWfs extends MapContextBaseLayer {
   featureType: string;
 }
 
+export interface MapContextLayerOgcApi extends MapContextBaseLayer{
+  type: 'ogcapi'
+  url: string
+  name: string
+  layerType: 'feature' | 'vectorTiles' | 'mapTiles' | 'record'
+}
+
 export interface MapContextLayerXyz extends MapContextBaseLayer {
   type: "xyz";
   url: string;
@@ -72,7 +80,8 @@ export type MapContextLayer =
   | MapContextLayerWmts
   | MapContextLayerWfs
   | MapContextLayerXyz
-  | MapContextLayerGeojson;
+  | MapContextLayerGeojson
+  | MapContextLayerOgcApi
 
 export type Coordinate = [number, number];
 

--- a/packages/openlayers/lib/map/apply-context-diff.test.ts
+++ b/packages/openlayers/lib/map/apply-context-diff.test.ts
@@ -17,8 +17,8 @@ import { applyContextDiffToMap } from "./apply-context-diff";
 import { beforeEach } from "vitest";
 import BaseLayer from "ol/layer/Base";
 
-function assertEqualsToModel(layer: any, layerModel: MapContextLayer) {
-  const reference = createLayer(layerModel) as any;
+async function assertEqualsToModel(layer: any, layerModel: MapContextLayer) {
+  const reference = await createLayer(layerModel) as any;
   expect(reference).toBeInstanceOf(layer.constructor);
   const refSource = reference.getSource() as any;
   const layerSource = layer.getSource() as any;
@@ -38,16 +38,16 @@ describe("applyContextDiffToMap", () => {
   let map: Map;
   let layersArray: BaseLayer[];
 
-  beforeEach(() => {
+  beforeEach(async () => {
     context = {
       ...SAMPLE_CONTEXT,
       layers: [SAMPLE_LAYER2, SAMPLE_LAYER1],
     };
-    map = createMapFromContext(context);
+    map = await createMapFromContext(context);
   });
 
   describe("no change", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       diff = {
         layersAdded: [],
         layersChanged: [],
@@ -55,7 +55,7 @@ describe("applyContextDiffToMap", () => {
         layersReordered: [],
         viewChanges: {},
       };
-      applyContextDiffToMap(map, diff);
+      await applyContextDiffToMap(map, diff);
       layersArray = map.getLayers().getArray();
     });
     it("does not affect the map", () => {
@@ -159,12 +159,12 @@ describe("applyContextDiffToMap", () => {
 
   describe("reordering", () => {
     describe("three layers reordered", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         context = {
           ...SAMPLE_CONTEXT,
           layers: [SAMPLE_LAYER1, SAMPLE_LAYER2, SAMPLE_LAYER3],
         };
-        map = createMapFromContext(context);
+        map = await createMapFromContext(context);
         diff = {
           layersAdded: [],
           layersChanged: [],
@@ -195,12 +195,12 @@ describe("applyContextDiffToMap", () => {
     });
 
     describe("four layers reordered", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         context = {
           ...SAMPLE_CONTEXT,
           layers: [SAMPLE_LAYER1, SAMPLE_LAYER3, SAMPLE_LAYER4, SAMPLE_LAYER2],
         };
-        map = createMapFromContext(context);
+        map = await createMapFromContext(context);
         diff = {
           layersAdded: [],
           layersChanged: [],
@@ -234,13 +234,13 @@ describe("applyContextDiffToMap", () => {
 
   describe("combined changes", () => {
     let changedLayer: MapContextLayer;
-    beforeEach(() => {
-      changedLayer = { ...SAMPLE_LAYER3, extras: { prop: true } };
+    beforeEach(async () => {
+      changedLayer = {...SAMPLE_LAYER3, extras: {prop: true}};
       context = {
         ...context,
         layers: [SAMPLE_LAYER1, SAMPLE_LAYER5, SAMPLE_LAYER3, SAMPLE_LAYER4],
       };
-      map = createMapFromContext(context);
+      map = await createMapFromContext(context);
       diff = {
         layersAdded: [
           {

--- a/packages/openlayers/lib/map/apply-context-diff.ts
+++ b/packages/openlayers/lib/map/apply-context-diff.ts
@@ -7,16 +7,16 @@ import { createLayer } from "./create-map";
  * @param map
  * @param contextDiff
  */
-export function applyContextDiffToMap(
-  map: Map,
-  contextDiff: MapContextDiff,
-): Map {
+export async function applyContextDiffToMap(
+    map: Map,
+    contextDiff: MapContextDiff,
+): Promise<Map> {
   const layers = map.getLayers();
 
   // removed layers (sorted by descending position)
   if (contextDiff.layersRemoved.length > 0) {
     const removed = contextDiff.layersRemoved.sort(
-      (a, b) => b.position - a.position,
+        (a, b) => b.position - a.position,
     );
     for (const layerRemoved of removed) {
       layers.item(layerRemoved.position).dispose();
@@ -25,23 +25,26 @@ export function applyContextDiffToMap(
   }
 
   // insert added layers
-  for (const layerAdded of contextDiff.layersAdded) {
-    createLayer(layerAdded.layer).then(layer => {
-      if (layerAdded.position >= layers.getLength()) {
-        layers.push(layer);
-      } else {
-        layers.insertAt(layerAdded.position, layer);
-      }
-    });
-  }
+  const newLayers = await Promise.all(
+      contextDiff.layersAdded.map((layerAdded) => createLayer(layerAdded.layer))
+  );
+
+  newLayers.forEach((layer, index) => {
+    const position = contextDiff.layersAdded[index].position;
+    if (position >= layers.getLength()) {
+      layers.push(layer);
+    } else {
+      layers.insertAt(position, layer);
+    }
+  });
 
   // move reordered layers (sorted by ascending new position)
   if (contextDiff.layersReordered.length > 0) {
     const reordered = contextDiff.layersReordered.sort(
-      (a, b) => a.newPosition - b.newPosition,
+        (a, b) => a.newPosition - b.newPosition,
     );
     const olLayers = reordered.map((layer) =>
-      layers.item(layer.previousPosition),
+        layers.item(layer.previousPosition),
     );
     const layersArray = layers.getArray();
     for (let i = 0; i < reordered.length; i++) {

--- a/packages/openlayers/lib/map/apply-context-diff.ts
+++ b/packages/openlayers/lib/map/apply-context-diff.ts
@@ -26,12 +26,13 @@ export function applyContextDiffToMap(
 
   // insert added layers
   for (const layerAdded of contextDiff.layersAdded) {
-    const layer = createLayer(layerAdded.layer);
-    if (layerAdded.position >= layers.getLength()) {
-      layers.push(layer);
-    } else {
-      layers.insertAt(layerAdded.position, layer);
-    }
+    createLayer(layerAdded.layer).then(layer => {
+      if (layerAdded.position >= layers.getLength()) {
+        layers.push(layer);
+      } else {
+        layers.insertAt(layerAdded.position, layer);
+      }
+    });
   }
 
   // move reordered layers (sorted by ascending new position)
@@ -52,7 +53,9 @@ export function applyContextDiffToMap(
   // recreate changed layers
   for (const layerChanged of contextDiff.layersChanged) {
     layers.item(layerChanged.position).dispose();
-    layers.setAt(layerChanged.position, createLayer(layerChanged.layer));
+    createLayer(layerChanged.layer).then(layer => {
+      layers.setAt(layerChanged.position, layer);
+    });
   }
   return map;
 }

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -30,7 +30,6 @@ import {
   createView,
   resetMapFromContext,
 } from "./create-map";
-import {describe} from "vitest";
 
 describe("MapContextService", () => {
   describe("#createLayer", () => {

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -15,6 +15,7 @@ import {
   MAP_CTX_LAYER_WFS_FIXTURE,
   MAP_CTX_LAYER_WMS_FIXTURE,
   MAP_CTX_LAYER_XYZ_FIXTURE,
+  MAP_CTX_LAYER_OGCAPI_FIXTURE,
 } from "@geospatial-sdk/core/fixtures/map-context.fixtures";
 import {
   MapContext,
@@ -29,6 +30,7 @@ import {
   createView,
   resetMapFromContext,
 } from "./create-map";
+import {describe} from "vitest";
 
 describe("MapContextService", () => {
   describe("#createLayer", () => {
@@ -62,7 +64,33 @@ describe("MapContextService", () => {
         );
       });
     });
-
+    describe("OGCAPI", () => {
+        beforeEach(() => {
+            layerModel = MAP_CTX_LAYER_OGCAPI_FIXTURE;
+            layer = createLayer(layerModel);
+        });
+        it("create a vector tile layer", () => {
+            expect(layer).toBeTruthy();
+            expect(layer).toBeInstanceOf(VectorLayer);
+        });
+        it("set correct layer properties", () => {
+            expect(layer.getVisible()).toBe(true);
+            expect(layer.getOpacity()).toBe(1);
+            expect(layer.get("label")).toBeUndefined();
+            expect(layer.getSource()?.getAttributions()).toBeNull();
+        });
+        it("create a OGCVectorTile source", () => {
+            const source = layer.getSource();
+            expect(source).toBeInstanceOf(VectorSource);
+        });
+        it("set correct url", () => {
+            const source = layer.getSource() as VectorSource;
+            const url = source.getUrl();
+            expect(url).toBe(
+            "https://demo.ldproxy.net/zoomstack/collections/airports/items?f=json",
+            );
+        });
+    });
     describe("WMS", () => {
       beforeEach(() => {
         (layerModel = MAP_CTX_LAYER_WMS_FIXTURE),

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -36,9 +36,9 @@ describe("MapContextService", () => {
     let layerModel: MapContextLayer, layer: Layer;
 
     describe("XYZ", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         layerModel = MAP_CTX_LAYER_XYZ_FIXTURE;
-        layer = createLayer(layerModel);
+        layer = await createLayer(layerModel);
       });
       it("create a tile layer", () => {
         expect(layer).toBeTruthy();
@@ -64,9 +64,9 @@ describe("MapContextService", () => {
       });
     });
     describe("OGCAPI", () => {
-        beforeEach(() => {
-            layerModel = MAP_CTX_LAYER_OGCAPI_FIXTURE;
-            layer = createLayer(layerModel);
+        beforeEach(async () => {
+          layerModel = MAP_CTX_LAYER_OGCAPI_FIXTURE;
+          layer = await createLayer(layerModel);
         });
         it("create a vector tile layer", () => {
             expect(layer).toBeTruthy();
@@ -91,9 +91,9 @@ describe("MapContextService", () => {
         });
     });
     describe("WMS", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         (layerModel = MAP_CTX_LAYER_WMS_FIXTURE),
-          (layer = createLayer(layerModel));
+            (layer = await createLayer(layerModel));
       });
       it("create a tile layer", () => {
         expect(layer).toBeTruthy();
@@ -131,9 +131,9 @@ describe("MapContextService", () => {
     });
 
     describe("WFS", () => {
-      beforeEach(() => {
+      beforeEach(async () => {
         (layerModel = MAP_CTX_LAYER_WFS_FIXTURE),
-          (layer = createLayer(layerModel));
+            (layer = await createLayer(layerModel));
       });
       it("create a vector layer", () => {
         expect(layer).toBeTruthy();
@@ -143,6 +143,9 @@ describe("MapContextService", () => {
         expect(layer.getVisible()).toBe(true);
         expect(layer.getOpacity()).toBe(0.5);
         expect(layer.get("label")).toBe("Communes");
+        const source = layer.getSource();
+        expect(source).toBeInstanceOf(VectorSource);
+
         const attributions = layer.getSource()?.getAttributions();
         expect(attributions).not.toBeNull();
         // @ts-ignore
@@ -156,16 +159,16 @@ describe("MapContextService", () => {
         const source = layer.getSource() as VectorSource;
         const urlLoader = source.getUrl() as Function;
         expect(urlLoader([10, 20, 30, 40])).toBe(
-          "https://www.geograndest.fr/geoserver/region-grand-est/ows?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application%2Fjson&typename=ms%3Acommune_actuelle_3857&srsname=EPSG%3A3857&bbox=10%2C20%2C30%2C40%2CEPSG%3A3857",
+          "https://www.geograndest.fr/geoserver/region-grand-est/ows?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application%2Fjson&typename=ms%3Acommune_actuelle_3857&srsname=EPSG%3A3857&bbox=10%2C20%2C30%2C40%2CEPSG%3A3857&maxFeatures=10000",
         );
       });
     });
 
     describe("GEOJSON", () => {
       describe("with inline data", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
           layerModel = MAP_CTX_LAYER_GEOJSON_FIXTURE;
-          layer = createLayer(layerModel);
+          layer = await createLayer(layerModel);
         });
         it("create a VectorLayer", () => {
           expect(layer).toBeTruthy();
@@ -189,10 +192,10 @@ describe("MapContextService", () => {
         });
       });
       describe("with inline data as string", () => {
-        beforeEach(() => {
-          layerModel = { ...MAP_CTX_LAYER_GEOJSON_FIXTURE };
+        beforeEach(async () => {
+          layerModel = {...MAP_CTX_LAYER_GEOJSON_FIXTURE};
           layerModel.data = JSON.stringify(layerModel.data);
-          layer = createLayer(layerModel);
+          layer = await createLayer(layerModel);
         });
         it("create a VectorLayer", () => {
           expect(layer).toBeTruthy();
@@ -212,7 +215,7 @@ describe("MapContextService", () => {
         });
       });
       describe("with invalid inline data as string", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
           const spy = vi.spyOn(window.console, "warn");
           spy.mockClear();
           layerModel = {
@@ -220,7 +223,7 @@ describe("MapContextService", () => {
             url: undefined,
             data: "blargz",
           };
-          layer = createLayer(layerModel);
+          layer = await createLayer(layerModel);
         });
         it("create a VectorLayer", () => {
           expect(layer).toBeTruthy();
@@ -236,9 +239,9 @@ describe("MapContextService", () => {
         });
       });
       describe("with remote file url", () => {
-        beforeEach(() => {
+        beforeEach(async () => {
           layerModel = MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE;
-          layer = createLayer(layerModel);
+          layer = await createLayer(layerModel);
         });
         it("create a VectorLayer", () => {
           expect(layer).toBeTruthy();
@@ -265,8 +268,8 @@ describe("MapContextService", () => {
     let map: Map;
     describe("from center and zoom", () => {
       const contextModel = MAP_CTX_FIXTURE;
-      beforeEach(() => {
-        map = createMapFromContext(contextModel);
+      beforeEach(async () => {
+        map = await createMapFromContext(contextModel);
         view = createView(contextModel.view, map);
       });
       it("create a view", () => {

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -18,6 +18,9 @@ import { fromLonLat } from "ol/proj";
 import { bbox as bboxStrategy } from "ol/loadingstrategy";
 import { removeSearchParams } from "@geospatial-sdk/core";
 import { defaultStyle } from "./styles";
+import VectorTileLayer from "ol/layer/VectorTile";
+import {OGCMapTile, OGCVectorTile} from "ol/source";
+import {MVT} from "ol/format";
 
 const geosjonFormat = new GeoJSON();
 
@@ -33,6 +36,32 @@ export function createLayer(layerModel: MapContextLayer): Layer {
         }),
       });
       break;
+    case "ogcapi":
+      if (layerModel.layerType === 'vectorTiles') {
+        layer = new VectorTileLayer({
+          source: new OGCVectorTile({
+            url: layerModel.url,
+            format: new MVT(),
+          }),
+        })
+        break;
+      } else if (layerModel.layerType === 'mapTiles') {
+        layer = new TileLayer({
+          source: new OGCMapTile({
+            url: layerModel.url,
+          }),
+        })
+        break;
+      } else {
+        layer = new VectorLayer({
+          source: new VectorSource({
+            format: new GeoJSON(),
+            url: layerModel.url,
+          }),
+          style,
+        })
+        break;
+      }
     case "wms":
       layer = new TileLayer({
         source: new TileWMS({

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -35,6 +35,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
       layer = new TileLayer({
         source: new XYZ({
           url: layerModel.url,
+          attributions: layerModel.attributions,
         }),
       });
       break;
@@ -44,6 +45,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
           url: removeSearchParams(layerModel.url, ["request", "service"]),
           params: { LAYERS: layerModel.name },
           gutter: 20,
+          attributions: layerModel.attributions,
         }),
       });
       break;
@@ -58,7 +60,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
       });
       new WfsEndpoint(layerModel.url).isReady().then((endpoint) => {
         const featureType =
-            endpoint.getSingleFeatureTypeName() ?? layerModel.name;
+            endpoint.getSingleFeatureTypeName() ?? layerModel.featureType;
         olLayer.setSource(
             new VectorSource({
               format: new GeoJSON(),
@@ -72,6 +74,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
                 });
               },
               strategy: bboxStrategy,
+              attributions: layerModel.attributions,
             }),
         );
       });
@@ -84,6 +87,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
           source: new VectorSource({
             format: new GeoJSON(),
             url: layerModel.url,
+            attributions: layerModel.attributions,
           }),
           style,
         });
@@ -104,6 +108,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
         layer = new VectorLayer({
           source: new VectorSource({
             features,
+            attributions: layerModel.attributions,
           }),
           style,
         });
@@ -120,6 +125,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
             source: new OGCVectorTile({
               url: layerUrl,
               format: new MVT(),
+              attributions: layerModel.attributions,
             }),
           });
         } else if (layerModel.useTiles === 'map') {
@@ -127,6 +133,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
           layer = new TileLayer({
             source: new OGCMapTile({
               url: layerUrl,
+              attributions: layerModel.attributions,
             }),
           });
         }
@@ -136,6 +143,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
           source: new VectorSource({
             format: new GeoJSON(),
             url: layerUrl,
+            attributions: layerModel.attributions,
           }),
           style,
         });

--- a/packages/openlayers/mocks/ogc-client.ts
+++ b/packages/openlayers/mocks/ogc-client.ts
@@ -1,0 +1,69 @@
+export class WmtsEndpoint {
+  constructor(private url) {}
+  isReady() {
+    return Promise.resolve({
+      getLayerByName: (name) => {
+        if (this.url.indexOf("error") > -1) {
+          throw new Error("Something went wrong");
+        }
+        return {
+          name,
+          latLonBoundingBox: [1.33, 48.81, 4.3, 51.1],
+        };
+      },
+    });
+  }
+}
+
+export class WfsEndpoint {
+  constructor(private url) {}
+
+  isReady() {
+    return Promise.resolve({
+      getLayerByName: (name) => {
+        if (this.url.indexOf("error") > -1) {
+          throw new Error("Something went wrong");
+        }
+        return {
+          name,
+          latLonBoundingBox: [1.33, 48.81, 4.3, 51.1],
+        };
+      },
+      getSingleFeatureTypeName: () => {
+        return "ms:commune_actuelle_3857";
+      },
+      getFeatureUrl: () => {
+        return "https://www.geograndest.fr/geoserver/region-grand-est/ows?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application%2Fjson&typename=ms%3Acommune_actuelle_3857&srsname=EPSG%3A3857&bbox=10%2C20%2C30%2C40%2CEPSG%3A3857&maxFeatures=10000";
+      },
+    });
+  }
+}
+
+export class OgcApiEndpoint {
+  constructor(private url: string) {
+    // newEndpointCall(url) // to track endpoint creation
+  }
+  getCollectionInfo() {
+    if (this.url.indexOf("error.http") > -1) {
+      return Promise.reject({
+        type: "http",
+        info: "Something went wrong",
+        httpStatus: 403,
+      });
+    }
+    return Promise.resolve({
+      bulkDownloadLinks: { json: "http://json", csv: "http://csv" },
+    });
+  }
+  allCollections = Promise.resolve([{ name: "collection1" }]);
+  featureCollections =
+    this.url.indexOf("error.http") > -1
+      ? Promise.reject(new Error())
+      : Promise.resolve(["collection1", "collection2"]);
+  getCollectionItem(collection, id) {
+    return Promise.resolve("item1");
+  }
+  getCollectionItemsUrl(collection) {
+    return "https://demo.ldproxy.net/zoomstack/collections/airports/items?f=json";
+  }
+}

--- a/packages/openlayers/vitest.config.ts
+++ b/packages/openlayers/vitest.config.ts
@@ -1,9 +1,13 @@
 import { defineProject } from "vitest/config";
+import {resolve} from 'path'
 
 export default defineProject({
   test: {
     environment: "jsdom",
     globals: true,
     setupFiles: ["./test-setup.ts"],
+      alias: {
+        '@camptocamp/ogc-client': resolve('./mocks/ogc-client.ts')
+      }
   },
 });


### PR DESCRIPTION
### Description

This PR introduces OGC API layer support and updates to WFS to make use of `ogc-client`

- Added `MapContextLayerOgcApi` interface in map-context.ts.
- Updated `createLayer` function in `create-map.ts` to handle OGC API layers.
- Added `MAP_CTX_LAYER_OGCAPI_FIXTURE` in `map-context.fixtures.ts`.
