### PR TITLE
Add Utility Functions for Modifying Layers in Map Context

### DIFF
--- a/packages/core/lib/utils/map-context.test.ts
+++ b/packages/core/lib/utils/map-context.test.ts
@@ -1,15 +1,16 @@
 import { describe } from "vitest";
 import {
-  getLayerHash,
-  getLayerPosition,
-  isLayerSame,
-  isLayerSameAndUnchanged,
+    addLayerToContext, changeLayerPositionInContext,
+    getLayerHash,
+    getLayerPosition,
+    isLayerSame,
+    isLayerSameAndUnchanged, removeLayerFromContext, replaceLayerInContext,
 } from "./map-context";
 import { MapContext } from "../model";
 import {
-  SAMPLE_CONTEXT,
-  SAMPLE_LAYER1,
-  SAMPLE_LAYER2,
+    SAMPLE_CONTEXT,
+    SAMPLE_LAYER1,
+    SAMPLE_LAYER2, SAMPLE_LAYER3,
 } from "../../fixtures/map-context.fixtures";
 
 describe("Map context utils", () => {
@@ -299,5 +300,57 @@ describe("Map context utils", () => {
       expect(getLayerPosition(context, SAMPLE_LAYER1)).toBe(0);
       expect(getLayerPosition(context, SAMPLE_LAYER2)).toBe(1);
     });
+  });
+  describe("addLayerToContext", () => {
+    it("adds a layer to the context", () => {
+      const context: MapContext = {
+        ...SAMPLE_CONTEXT,
+        layers: [SAMPLE_LAYER1],
+      };
+      const newLayer = { ...SAMPLE_LAYER2, name: "newLayer" };
+      const newContext = addLayerToContext(context, newLayer);
+      expect(newContext.layers).toEqual([SAMPLE_LAYER1, newLayer]);
+    });
+    it("adds a layer at a specific position", () => {
+      const context: MapContext = {
+        ...SAMPLE_CONTEXT,
+        layers: [SAMPLE_LAYER1, SAMPLE_LAYER2],
+      };
+      const newLayer = { ...SAMPLE_LAYER2, name: "newLayer" };
+      const newContext = addLayerToContext(context, newLayer, 1);
+      expect(newContext.layers).toEqual([SAMPLE_LAYER1, newLayer, SAMPLE_LAYER2]);
+    });
+  });
+  describe("removeLayerFromContext", ()  =>{
+    it("removes a layer from the context", () => {
+      const context: MapContext = {
+        ...SAMPLE_CONTEXT,
+        layers: [SAMPLE_LAYER1, SAMPLE_LAYER2],
+      };
+      const newContext = removeLayerFromContext(context, SAMPLE_LAYER1);
+      expect(newContext.layers).toEqual([SAMPLE_LAYER2]);
+    });
+  });
+  describe("replaceLayerInContext", () => {
+    it("replaces a layer in the context", () => {
+         const context: MapContext = {
+            ...SAMPLE_CONTEXT,
+            layers: [SAMPLE_LAYER1, SAMPLE_LAYER2],
+        };
+        const replacementLayer = { ...SAMPLE_LAYER3};
+        const existingLayer = { ...SAMPLE_LAYER1};
+        const newContext = replaceLayerInContext(context, existingLayer, replacementLayer);
+        expect(newContext.layers).toEqual([replacementLayer, SAMPLE_LAYER2]);
+    });
+  });
+  describe("changeLayerPositionInContext", () => {
+     it("changes the position of a layer in the context", () => {
+        const context: MapContext = {
+            ...SAMPLE_CONTEXT,
+            layers: [SAMPLE_LAYER1, SAMPLE_LAYER2],
+        };
+        const newContext = changeLayerPositionInContext(context, SAMPLE_LAYER1, 1);
+        expect(newContext.layers).toEqual([SAMPLE_LAYER2, SAMPLE_LAYER1]);
+     });
   });
 });

--- a/packages/core/lib/utils/map-context.ts
+++ b/packages/core/lib/utils/map-context.ts
@@ -49,3 +49,86 @@ export function getLayerPosition(
 ): number {
   return context.layers.findIndex((l) => isLayerSame(layerModel, l));
 }
+
+/**
+ * Adds a layer to the context at a specific position or at the end if no position is specified.
+ *
+ * @param {MapContext} context - The current map context.
+ * @param {MapContextLayer} layerModel - The layer to be added.
+ * @param {number} [position] - The position at which to add the layer. If not specified, the layer is added at the end.
+ * @returns {MapContext} - The new map context with the added layer.
+ */
+
+export function addLayerToContext(
+  context: MapContext,
+  layerModel: MapContextLayer,
+  position?: number,
+): MapContext {
+  const newContext = { ...context, layers: [...context.layers]};
+  if (position !== undefined) {
+    newContext.layers.splice(position, 0, layerModel);
+  } else {
+    newContext.layers.push(layerModel);
+  }
+  return newContext;
+}
+
+/**
+ * Removes a layer from the context.
+ *
+ * @param {MapContext} context - The current map context.
+ * @param {MapContextLayer} layerModel - The layer to be removed.
+ * @returns {MapContext} - The new map context without the removed layer.
+ */
+
+export function removeLayerFromContext(
+    context: MapContext,
+    layerModel: MapContextLayer,
+    ): MapContext {
+    const newContext = { ...context, layers: [...context.layers] };
+    const position = getLayerPosition(context, layerModel);
+    if (position >= 0) {
+        newContext.layers.splice(position, 1);
+    }
+    return newContext;
+}
+
+/**
+ * Replaces a layer in the context with a new layer.
+ *
+ * @param {MapContext} context - The current map context.
+ * @param {MapContextLayer} layerModel - The layer to be replaced.
+ * @param {MapContextLayer} replacement - The new layer that will replace the old one.
+ * @returns {MapContext} - The new map context with the replaced layer.
+ */
+
+export function replaceLayerInContext(
+  context: MapContext,
+  layerModel: MapContextLayer,
+  replacement: MapContextLayer,
+): MapContext {
+  const newContext = { ...context, layers: [...context.layers] };
+  const position = getLayerPosition(context, layerModel);
+  if (position >= 0) {
+    newContext.layers.splice(position, 1, replacement);
+  }
+  return newContext;
+}
+
+/**
+ * Changes the position of a layer in the context.
+ *
+ * @param {MapContext} context - The current map context.
+ * @param {MapContextLayer} layerModel - The layer whose position is to be changed.
+ * @param {number} position - The new position for the layer.
+ * @returns {MapContext} - The new map context with the layer moved to the new position.
+ */
+
+export function changeLayerPositionInContext(
+  context: MapContext,
+  layerModel: MapContextLayer,
+  position: number,
+): MapContext {
+  const newContext = removeLayerFromContext(context, layerModel);
+  return addLayerToContext(newContext, layerModel, position);
+}


### PR DESCRIPTION
### Description

This pull request introduces a set of utility functions designed to simplify the process of modifying layers within a map context. These functions provide a straightforward way to add, remove, replace, and change the position of layers in the context.

The following functions have been added:

1. `addLayerToContext`: This function adds a layer to the context at a specific position or at the end if no position is specified.

2. `removeLayerFromContext`: This function removes a layer from the context.

3. `replaceLayerInContext`: This function replaces a layer in the context with a new layer.

4. `changeLayerPositionInContext`: This function changes the position of a layer in the context.

These changes will help streamline the process of manipulating layers within a map context, making our codebase more efficient and maintainable.