### PR TITLE
Create a layer based on a Mapbox-hosted style

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
       ],
       "dependencies": {
         "@camptocamp/ogc-client": "1.1.1-dev.9671ef4",
-        "@geospatial-sdk/core": "*"
+        "@geospatial-sdk/core": "*",
+        "ol-mapbox-style": "^12.3.4"
       },
       "devDependencies": {
         "@babel/cli": "^7.23.9",
@@ -3012,6 +3013,48 @@
         "node": ">=18.0.0"
       }
     },
+    "node_modules/@mapbox/jsonlint-lines-primitives": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
+      "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@mapbox/mapbox-gl-style-spec": {
+      "version": "13.28.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-style-spec/-/mapbox-gl-style-spec-13.28.0.tgz",
+      "integrity": "sha512-B8xM7Fp1nh5kejfIl4SWeY0gtIeewbuRencqO3cJDrCHZpaPg7uY+V8abuR+esMeuOjRl5cLhVTP40v+1ywxbg==",
+      "license": "ISC",
+      "dependencies": {
+        "@mapbox/jsonlint-lines-primitives": "~2.0.2",
+        "@mapbox/point-geometry": "^0.1.0",
+        "@mapbox/unitbezier": "^0.0.0",
+        "csscolorparser": "~1.0.2",
+        "json-stringify-pretty-compact": "^2.0.0",
+        "minimist": "^1.2.6",
+        "rw": "^1.3.3",
+        "sort-object": "^0.3.2"
+      },
+      "bin": {
+        "gl-style-composite": "bin/gl-style-composite.js",
+        "gl-style-format": "bin/gl-style-format.js",
+        "gl-style-migrate": "bin/gl-style-migrate.js",
+        "gl-style-validate": "bin/gl-style-validate.js"
+      }
+    },
+    "node_modules/@mapbox/point-geometry": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
+      "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
+      "license": "ISC"
+    },
+    "node_modules/@mapbox/unitbezier": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
+      "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/@nicolo-ribaudo/chokidar-2": {
       "version": "2.1.8-no-fsevents.3",
       "resolved": "https://registry.npmjs.org/@nicolo-ribaudo/chokidar-2/-/chokidar-2-2.1.8-no-fsevents.3.tgz",
@@ -3588,8 +3631,7 @@
     "node_modules/@petamoriken/float16": {
       "version": "3.8.4",
       "resolved": "https://registry.npmjs.org/@petamoriken/float16/-/float16-3.8.4.tgz",
-      "integrity": "sha512-kB+NJ5Br56ZhElKsf0pM7/PQfrDdDVMRz8f0JM6eVOGE+L89z9hwcst9QvWBBnazzuqGTGtPsJNZoQ1JdNiGSQ==",
-      "devOptional": true
+      "integrity": "sha512-kB+NJ5Br56ZhElKsf0pM7/PQfrDdDVMRz8f0JM6eVOGE+L89z9hwcst9QvWBBnazzuqGTGtPsJNZoQ1JdNiGSQ=="
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -5673,14 +5715,12 @@
     "node_modules/color-name": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "devOptional": true
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
     "node_modules/color-parse": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.0.tgz",
       "integrity": "sha512-g2Z+QnWsdHLppAbrpcFWo629kLOnOPtpxYV69GCqm92gqSgyXbzlfyN3MXs0412fPBkFmiuS+rXposgBgBa6Kg==",
-      "devOptional": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -5689,7 +5729,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
       "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
-      "devOptional": true,
       "dependencies": {
         "color-parse": "^2.0.0",
         "color-space": "^2.0.0"
@@ -5698,8 +5737,7 @@
     "node_modules/color-space": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.0.1.tgz",
-      "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA==",
-      "devOptional": true
+      "integrity": "sha512-nKqUYlo0vZATVOFHY810BSYjmCARrG7e5R3UE3CQlyjJTvv5kSSmPG1kzm/oDyyqjehM+lW1RnEt9It9GNa5JA=="
     },
     "node_modules/color-support": {
       "version": "1.1.3",
@@ -5995,6 +6033,12 @@
       "engines": {
         "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
       }
+    },
+    "node_modules/csscolorparser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
+      "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
+      "license": "MIT"
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -6310,8 +6354,7 @@
     "node_modules/earcut": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "devOptional": true
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -7259,7 +7302,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/geotiff/-/geotiff-2.1.1.tgz",
       "integrity": "sha512-Ss6HQEhrlR2v0FmOGq88l0wa2oCmmGi6rXAMiUxR/T7Xe98evypEmyiji7lvVeVR/AXuxK0xDCWcwfWkSmOrAA==",
-      "devOptional": true,
       "dependencies": {
         "@petamoriken/float16": "^3.4.7",
         "lerc": "^3.0.0",
@@ -7278,7 +7320,6 @@
       "version": "6.1.2",
       "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-6.1.2.tgz",
       "integrity": "sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==",
-      "devOptional": true,
       "engines": {
         "node": ">=12"
       },
@@ -7748,7 +7789,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -8430,6 +8470,12 @@
       "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
       "dev": true
     },
+    "node_modules/json-stringify-pretty-compact": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-2.0.0.tgz",
+      "integrity": "sha512-WRitRfs6BGq4q8gTgOy4ek7iPFXjbra0H3PmDLKm2xnZ+Gh1HUhiKGgCZkSPNULlP7mvfu6FV/mOLhCarspADQ==",
+      "license": "MIT"
+    },
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
@@ -8512,8 +8558,7 @@
     "node_modules/lerc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/lerc/-/lerc-3.0.0.tgz",
-      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww==",
-      "devOptional": true
+      "integrity": "sha512-Rm4J/WaHhRa93nCN2mwWDZFoRVF18G1f47C+kvQWyHGEZxFpTUi73p7lMVSAndyxGt6lJ2/CFbOcf9ra5p8aww=="
     },
     "node_modules/lerna": {
       "version": "8.0.2",
@@ -8948,6 +8993,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/mapbox-to-css-font": {
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/mapbox-to-css-font/-/mapbox-to-css-font-2.4.5.tgz",
+      "integrity": "sha512-VJ6nB8emkO9VODI0Fk+TQ/0zKBTqmf/Pkt8Xv0kHstoc0iXRajA00DAid4Kc3K5xeFIOoiZrVxijEzj0GLVO2w==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/mark.js": {
       "version": "8.11.1",
       "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
@@ -9178,7 +9229,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -10137,7 +10187,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/ol/-/ol-8.2.0.tgz",
       "integrity": "sha512-/m1ddd7Jsp4Kbg+l7+ozR5aKHAZNQOBAoNZ5pM9Jvh4Etkf0WGkXr9qXd7PnhmwiC1Hnc2Toz9XjCzBBvexfXw==",
-      "devOptional": true,
       "dependencies": {
         "color-rgba": "^3.0.0",
         "color-space": "^2.0.1",
@@ -10149,6 +10198,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/openlayers"
+      }
+    },
+    "node_modules/ol-mapbox-style": {
+      "version": "12.3.4",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.3.4.tgz",
+      "integrity": "sha512-TxGJZw4hmvc6n5dHSyAE8ZpgALJ6hVG5Q9yl0j2Q1KmLS9iq4wMpb383TAitWiG86SvJV4oDkWMGkyyMLfVyew==",
+      "license": "BSD-2-Clause",
+      "dependencies": {
+        "@mapbox/mapbox-gl-style-spec": "^13.23.1",
+        "mapbox-to-css-font": "^2.4.1"
+      },
+      "peerDependencies": {
+        "ol": "*"
       }
     },
     "node_modules/once": {
@@ -10664,8 +10726,7 @@
     "node_modules/pako": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/pako/-/pako-2.1.0.tgz",
-      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug==",
-      "devOptional": true
+      "integrity": "sha512-w+eufiZ1WuJYgPXbV/PO3NCMEc3xqylkKHzp8bxp1uW4qaSNQUkwmLLEc3kKsfz8lpV1F8Ht3U1Cm+9Srog2ug=="
     },
     "node_modules/parent-module": {
       "version": "1.0.1",
@@ -10682,8 +10743,7 @@
     "node_modules/parse-headers": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.5.tgz",
-      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA==",
-      "devOptional": true
+      "integrity": "sha512-ft3iAoLOB/MlwbNXgzy43SWGP6sQki2jQvAyBg/zDFAgr9bfNWZIUj42Kw2eJIl8kEi4PbgE6U1Zau/HwI75HA=="
     },
     "node_modules/parse-json": {
       "version": "5.2.0",
@@ -10825,7 +10885,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.2.1.tgz",
       "integrity": "sha512-ClrV7pNOn7rtmoQVF4TS1vyU0WhYRnP92fzbfF75jAIwpnzdJXf8iTd4CMEqO4yUenH6NDqLiwjqlh6QgZzgLQ==",
-      "devOptional": true,
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -11037,8 +11096,7 @@
     "node_modules/protocol-buffers-schema": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
-      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "devOptional": true
+      "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw=="
     },
     "node_modules/protocols": {
       "version": "2.0.1",
@@ -11105,14 +11163,12 @@
     "node_modules/quickselect": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
-      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "devOptional": true
+      "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw=="
     },
     "node_modules/rbush": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/rbush/-/rbush-3.0.1.tgz",
       "integrity": "sha512-XRaVO0YecOpEuIvbhbpTrZgoiI6xBlz6hnlr6EHhd+0x9ase6EmeN+hdwwUaJvLcsFFQ8iWVF1GAK1yB0BWi0w==",
-      "devOptional": true,
       "dependencies": {
         "quickselect": "^2.0.0"
       }
@@ -11609,7 +11665,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
-      "devOptional": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -11784,6 +11839,12 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/rxjs": {
       "version": "7.8.1",
@@ -12163,6 +12224,22 @@
         "node": ">= 14"
       }
     },
+    "node_modules/sort-asc": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/sort-asc/-/sort-asc-0.1.0.tgz",
+      "integrity": "sha512-jBgdDd+rQ+HkZF2/OHCmace5dvpos/aWQpcxuyRs9QUbPRnkEJmYVo81PIGpjIdpOcsnJ4rGjStfDHsbn+UVyw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sort-desc": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/sort-desc/-/sort-desc-0.1.1.tgz",
+      "integrity": "sha512-jfZacW5SKOP97BF5rX5kQfJmRVZP5/adDUTY8fCSPvNcXDVpUEe2pr/iKGlcyZzchRJZrswnp68fgk3qBXgkJw==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/sort-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
@@ -12173,6 +12250,18 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/sort-object": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/sort-object/-/sort-object-0.3.2.tgz",
+      "integrity": "sha512-aAQiEdqFTTdsvUFxXm3umdo04J7MRljoVGbBlkH7BgNsMvVNAJyGj7C/wV1A8wHWAJj/YikeZbfuCKqhggNWGA==",
+      "dependencies": {
+        "sort-asc": "^0.1.0",
+        "sort-desc": "^0.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/source-map": {
@@ -13662,8 +13751,7 @@
     "node_modules/web-worker": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.3.0.tgz",
-      "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA==",
-      "devOptional": true
+      "integrity": "sha512-BSR9wyRsy/KOValMgd5kMyr3JzpdeoR9KVId8u5GVlTTAtNChlsE4yTxeY7zMdNSyOmoKBv8NH2qeRY9Tg+IaA=="
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -13938,8 +14026,7 @@
     "node_modules/xml-utils": {
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/xml-utils/-/xml-utils-1.7.0.tgz",
-      "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw==",
-      "devOptional": true
+      "integrity": "sha512-bWB489+RQQclC7A9OW8e5BzbT8Tu//jtAOvkYwewFr+Q9T9KDGvfzC1lp0pYPEQPEoPQLDkmxkepSC/2gIAZGw=="
     },
     "node_modules/xmlchars": {
       "version": "2.2.0",
@@ -14013,8 +14100,7 @@
     "node_modules/zstddec": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.1.0.tgz",
-      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg==",
-      "devOptional": true
+      "integrity": "sha512-w2NTI8+3l3eeltKAdK8QpiLo/flRAr2p8AGeakfMZOXBxOg9HIu4LVDxBi81sYgVhFhdJjv1OrB5ssI8uFPoLg=="
     },
     "packages/core": {
       "name": "@geospatial-sdk/core",
@@ -14032,7 +14118,8 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@geospatial-sdk/core": "^0.0.5-alpha.2",
-        "chroma-js": "^2.4.2"
+        "chroma-js": "^2.4.2",
+        "ol-mapbox-style": "^12.3.4"
       },
       "devDependencies": {
         "@types/chroma-js": "^2.4.3",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "@camptocamp/ogc-client": "1.1.1-dev.9671ef4",
-    "@geospatial-sdk/core": "*"
+    "@geospatial-sdk/core": "*",
+    "ol-mapbox-style": "^12.3.4"
   }
 }

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -1,4 +1,3 @@
-
 import { FeatureCollection, Geometry } from "geojson";
 
 export type LayerDimensions = Record<string, string>;
@@ -43,13 +42,19 @@ export interface MapContextLayerWfs extends MapContextBaseLayer {
   featureType: string;
 }
 
-export interface MapContextLayerOgcApi extends MapContextBaseLayer{
-  type: 'ogcapi'
-  url: string
-  collection: string
-  useTiles?: 'vector' | 'map'
-  tileMatrixSet?: string
-  options?: Record<string, string>
+export interface MapContextLayerOgcApi extends MapContextBaseLayer {
+  type: "ogcapi";
+  url: string;
+  collection: string;
+  useTiles?: "vector" | "map";
+  tileMatrixSet?: string;
+  options?: Record<string, string>;
+}
+
+export interface MapBoxVectoreLayer extends MapContextBaseLayer {
+  type: "mapbox-vector";
+  styleUrl: string;
+  accessToken: string;
 }
 
 export interface MapContextLayerXyz extends MapContextBaseLayer {
@@ -84,6 +89,7 @@ export type MapContextLayer =
   | MapContextLayerXyz
   | MapContextLayerGeojson
   | MapContextLayerOgcApi
+  | MapBoxVectoreLayer;
 
 export type Coordinate = [number, number];
 

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -19,9 +19,11 @@ import { bbox as bboxStrategy } from "ol/loadingstrategy";
 import { removeSearchParams } from "@geospatial-sdk/core";
 import { defaultStyle } from "./styles";
 import VectorTileLayer from "ol/layer/VectorTile";
-import {OGCMapTile, OGCVectorTile} from "ol/source";
-import {MVT} from "ol/format";
-import {OgcApiEndpoint, WfsEndpoint} from "@camptocamp/ogc-client";
+import { OGCMapTile, OGCVectorTile, Source } from "ol/source";
+import { MVT } from "ol/format";
+import { OgcApiEndpoint, WfsEndpoint } from "@camptocamp/ogc-client";
+import { MapboxVectorLayer } from "ol-mapbox-style";
+import LayerRenderer from "ol/renderer/Layer";
 
 const geosjonFormat = new GeoJSON();
 const WFS_MAX_FEATURES = 10000;
@@ -54,31 +56,38 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
     //   return new TileLayer({
     //     source: new WMTS(layerModel.options),
     //   })
-    case "wfs":{
+    case "wfs": {
       const olLayer = new VectorLayer({
         style,
       });
       new WfsEndpoint(layerModel.url).isReady().then((endpoint) => {
         const featureType =
-            endpoint.getSingleFeatureTypeName() ?? layerModel.featureType;
+          endpoint.getSingleFeatureTypeName() ?? layerModel.featureType;
         olLayer.setSource(
-            new VectorSource({
-              format: new GeoJSON(),
-              url: function (extent) {
-                return endpoint.getFeatureUrl(featureType, {
-                  maxFeatures: WFS_MAX_FEATURES,
-                  asJson: true,
-                  outputCrs: "EPSG:3857",
-                  extent: extent as [number, number, number, number],
-                  extentCrs: "EPSG:3857",
-                });
-              },
-              strategy: bboxStrategy,
-              attributions: layerModel.attributions,
-            }),
+          new VectorSource({
+            format: new GeoJSON(),
+            url: function (extent) {
+              return endpoint.getFeatureUrl(featureType, {
+                maxFeatures: WFS_MAX_FEATURES,
+                asJson: true,
+                outputCrs: "EPSG:3857",
+                extent: extent as [number, number, number, number],
+                extentCrs: "EPSG:3857",
+              });
+            },
+            strategy: bboxStrategy,
+            attributions: layerModel.attributions,
+          }),
         );
       });
       layer = olLayer;
+      break;
+    }
+    case "mapbox-vector": {
+      layer = new MapboxVectorLayer({
+        styleUrl: layerModel.styleUrl,
+        accessToken: layerModel.accessToken,
+      }) as unknown as Layer<Source, LayerRenderer<any>>;
       break;
     }
     case "geojson": {
@@ -119,8 +128,11 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
       const ogcEndpoint = await new OgcApiEndpoint(layerModel.url);
       let layerUrl: string;
       if (layerModel.useTiles) {
-        if (layerModel.useTiles === 'vector') {
-          layerUrl = await ogcEndpoint.getVectorTilesetUrl(layerModel.collection, layerModel.tileMatrixSet);
+        if (layerModel.useTiles === "vector") {
+          layerUrl = await ogcEndpoint.getVectorTilesetUrl(
+            layerModel.collection,
+            layerModel.tileMatrixSet,
+          );
           layer = new VectorTileLayer({
             source: new OGCVectorTile({
               url: layerUrl,
@@ -128,8 +140,11 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
               attributions: layerModel.attributions,
             }),
           });
-        } else if (layerModel.useTiles === 'map') {
-          layerUrl = await ogcEndpoint.getMapTilesetUrl(layerModel.collection, layerModel.tileMatrixSet);
+        } else if (layerModel.useTiles === "map") {
+          layerUrl = await ogcEndpoint.getMapTilesetUrl(
+            layerModel.collection,
+            layerModel.tileMatrixSet,
+          );
           layer = new TileLayer({
             source: new OGCMapTile({
               url: layerUrl,
@@ -138,7 +153,10 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
           });
         }
       } else {
-        layerUrl = await ogcEndpoint.getCollectionItemsUrl(layerModel.collection, layerModel.options);
+        layerUrl = await ogcEndpoint.getCollectionItemsUrl(
+          layerModel.collection,
+          layerModel.options,
+        );
         layer = new VectorLayer({
           source: new VectorSource({
             format: new GeoJSON(),
@@ -194,8 +212,8 @@ export function createView(viewModel: MapContextView, map: Map): View {
  * @param target
  */
 export async function createMapFromContext(
-    context: MapContext,
-    target?: string | HTMLElement,
+  context: MapContext,
+  target?: string | HTMLElement,
 ): Promise<Map> {
   const map = new Map({
     target,
@@ -208,7 +226,10 @@ export async function createMapFromContext(
  * @param map
  * @param context
  */
-export async function resetMapFromContext(map: Map, context: MapContext): Promise<Map> {
+export async function resetMapFromContext(
+  map: Map,
+  context: MapContext,
+): Promise<Map> {
   map.setView(createView(context.view, map));
   map.getLayers().clear();
   for (const layerModel of context.layers) {


### PR DESCRIPTION
This PR introduces support for Mapbox vector layers in the `createLayer` function within the `@geospatial-sdk/openlayers` package. The new case "mapbox-vector" has been added to handle layers with Mapbox vector tiles.

The MapboxVector layer from the [ol-mapbox-style](https://github.com/openlayers/ol-mapbox-style/) package allows you to create a layer based on a Mapbox-hosted style using a single vector source.