### PR TITLE
[Legend] Add `SLD_VERSION` Parameter to WMS Legend Requests

### DIFF
--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -26,7 +26,7 @@ function createWmsLegendUrl(
   layer: MapContextLayerWms,
   options: LegendOptions = {},
 ): URL {
-  const { format = "image/png", widthPxHint, heightPxHint } = options;
+  const { format = "image/png", widthPxHint, heightPxHint} = options;
 
   const legendUrl = new URL(
     removeSearchParams(layer.url, [
@@ -35,6 +35,8 @@ function createWmsLegendUrl(
       "FORMAT",
       "LAYER",
       "LAYERTITLE",
+      "SLD_VERSION",
+      "STYLE",
       "WIDTH",
       "HEIGHT",
     ]),
@@ -44,6 +46,7 @@ function createWmsLegendUrl(
   legendUrl.searchParams.set("FORMAT", format);
   legendUrl.searchParams.set("LAYER", layer.name);
   legendUrl.searchParams.set("LAYERTITLE", false.toString()); // Disable layer title for QGIS Server
+  legendUrl.searchParams.set("SLD_VERSION", "1.1.0"); // Default SLD version
 
   if (widthPxHint) {
     legendUrl.searchParams.set("WIDTH", widthPxHint.toString());

--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -26,7 +26,7 @@ function createWmsLegendUrl(
   layer: MapContextLayerWms,
   options: LegendOptions = {},
 ): URL {
-  const { format = "image/png", widthPxHint, heightPxHint} = options;
+  const { format = "image/png", widthPxHint, heightPxHint } = options;
 
   const legendUrl = new URL(
     removeSearchParams(layer.url, [
@@ -36,7 +36,6 @@ function createWmsLegendUrl(
       "LAYER",
       "LAYERTITLE",
       "SLD_VERSION",
-      "STYLE",
       "WIDTH",
       "HEIGHT",
     ]),


### PR DESCRIPTION
### Description

This PR introduces the `SLD_VERSION` parameter to the `GetLegendGraphic` request for WMS layers. Some WMS servers require this parameter to successfully generate legend graphics.