### PR TITLE
Fix: Use 12.4.0 fixed tag for ol-mapbox-style

### DIFF
--- a/apps/examples/package-lock.json
+++ b/apps/examples/package-lock.json
@@ -61,13 +61,13 @@
         "@geospatial-sdk/core": "^0.0.5-alpha.2",
         "chroma-js": "^2.4.2",
         "lodash.throttle": "^4.1.1",
-        "ol-mapbox-style": "^12.3.5"
+        "ol-mapbox-style": "12.4.0"
       },
       "devDependencies": {
         "@types/chroma-js": "^2.4.3",
         "@types/lodash.throttle": "^4.1.9",
         "ol": "^8.2.0",
-        "ol-mapbox-style": "^12.3.5"
+        "ol-mapbox-style": "12.4.0"
       },
       "peerDependencies": {
         "ol": ">6.x"

--- a/package-lock.json
+++ b/package-lock.json
@@ -11007,9 +11007,9 @@
       }
     },
     "node_modules/ol-mapbox-style": {
-      "version": "12.3.5",
-      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.3.5.tgz",
-      "integrity": "sha512-1tdq+jpzJ7BuqCeRpNV5u90X369MXDbHKpPPt0BNpbzi+4UEJ2dJIrd3eFQV9VbqvZeEIioEjyK7qOqXsUZs8w==",
+      "version": "12.4.0",
+      "resolved": "https://registry.npmjs.org/ol-mapbox-style/-/ol-mapbox-style-12.4.0.tgz",
+      "integrity": "sha512-P8Jg9AXSG6FpUNrADejpwMG0HbmHTZOJQQocACzaDL0QrU4kzmCvj06xUIKhTxT5mtC413pCVAbyXJ4mx0XFnQ==",
       "dev": true,
       "dependencies": {
         "@mapbox/mapbox-gl-style-spec": "^13.23.1",
@@ -15121,13 +15121,13 @@
         "@geospatial-sdk/core": "^0.0.5-alpha.2",
         "chroma-js": "^2.4.2",
         "lodash.throttle": "^4.1.1",
-        "ol-mapbox-style": "^12.3.5"
+        "ol-mapbox-style": "12.4.0"
       },
       "devDependencies": {
         "@types/chroma-js": "^2.4.3",
         "@types/lodash.throttle": "^4.1.9",
         "ol": "^8.2.0",
-        "ol-mapbox-style": "^12.3.5"
+        "ol-mapbox-style": "12.4.0"
       },
       "peerDependencies": {
         "ol": ">6.x"

--- a/packages/openlayers/package.json
+++ b/packages/openlayers/package.json
@@ -31,7 +31,7 @@
     "@types/chroma-js": "^2.4.3",
     "@types/lodash.throttle": "^4.1.9",
     "ol": "^8.2.0",
-    "ol-mapbox-style": "^12.3.5"
+    "ol-mapbox-style": "12.4.0"
   },
   "peerDependencies": {
     "ol": ">6.x"
@@ -40,7 +40,7 @@
     "@geospatial-sdk/core": "^0.0.5-alpha.2",
     "chroma-js": "^2.4.2",
     "lodash.throttle": "^4.1.1",
-    "ol-mapbox-style": "^12.3.5"
+    "ol-mapbox-style": "12.4.0"
   },
   "gitHead": "99dbb945a303b96e576a02a02bc0590785456bd3"
 }


### PR DESCRIPTION
Note: 12.5.0 causes `TypeError: Class extends value [object Object] is not a constructor or null` error in gn-ui tests