### PR TITLE
Introduce a new MVT layer type

### DIFF
--- a/packages/core/fixtures/map-context.fixtures.ts
+++ b/packages/core/fixtures/map-context.fixtures.ts
@@ -66,8 +66,8 @@ export const MAP_CTX_LAYER_MAPBLIBRE_STYLE_FIXTURE: MapContextLayerMapLibreStyle
   });
 export const MAP_CTX_LAYER_MVT_FIXTURE: MapContextLayerXyz = deepFreeze({
   type: "xyz",
-  url: "https://data.geopf.fr/tms/1.0.0/PLAN.IGN",
-  tileFormat: "mvt",
+  url: "https://data.geopf.fr/tms/1.0.0/PLAN.IGN/{z}/{x}/{y}.pbf",
+  tileFormat: "application/vnd.mapbox-vector-tile",
   accessToken: "abcdefgh",
 });
 

--- a/packages/core/fixtures/map-context.fixtures.ts
+++ b/packages/core/fixtures/map-context.fixtures.ts
@@ -4,6 +4,7 @@ import {
   MapContext,
   MapContextLayerGeojson,
   MapContextLayerMapLibreStyle,
+  MapContextLayerMvt,
   MapContextLayerOgcApi,
   MapContextLayerWfs,
   MapContextLayerWms,
@@ -64,6 +65,11 @@ export const MAP_CTX_LAYER_MAPBLIBRE_STYLE_FIXTURE: MapContextLayerMapLibreStyle
     styleUrl: "http://my.host.com/maplibre/style.json",
     accessToken: "abcdefgh",
   });
+export const MAP_CTX_LAYER_MVT_FIXTURE: MapContextLayerMvt = deepFreeze({
+  type: "mvt",
+  url: "https://data.geopf.fr/tms/1.0.0/PLAN.IGN",
+  accessToken: "abcdefgh",
+});
 
 export const MAP_CTX_VIEW_FIXTURE: MapContextView = deepFreeze({
   center: [7.75, 48.6],

--- a/packages/core/fixtures/map-context.fixtures.ts
+++ b/packages/core/fixtures/map-context.fixtures.ts
@@ -4,7 +4,6 @@ import {
   MapContext,
   MapContextLayerGeojson,
   MapContextLayerMapLibreStyle,
-  MapContextLayerMvt,
   MapContextLayerOgcApi,
   MapContextLayerWfs,
   MapContextLayerWms,
@@ -65,9 +64,10 @@ export const MAP_CTX_LAYER_MAPBLIBRE_STYLE_FIXTURE: MapContextLayerMapLibreStyle
     styleUrl: "http://my.host.com/maplibre/style.json",
     accessToken: "abcdefgh",
   });
-export const MAP_CTX_LAYER_MVT_FIXTURE: MapContextLayerMvt = deepFreeze({
-  type: "mvt",
+export const MAP_CTX_LAYER_MVT_FIXTURE: MapContextLayerXyz = deepFreeze({
+  type: "xyz",
   url: "https://data.geopf.fr/tms/1.0.0/PLAN.IGN",
+  tileFormat: "mvt",
   accessToken: "abcdefgh",
 });
 

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -64,7 +64,7 @@ export interface MapContextLayerMapLibreStyle extends MapContextBaseLayer {
 export interface MapContextLayerXyz extends MapContextBaseLayer {
   type: "xyz";
   url: string;
-  tileFormat?: string;
+  tileFormat?: "application/vnd.mapbox-vector-tile"; // If not specified, the system will automatically assume tiles are images.
 }
 
 interface LayerGeojson extends MapContextBaseLayer {

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -61,6 +61,12 @@ export interface MapContextLayerMapLibreStyle extends MapContextBaseLayer {
   accessToken?: string;
 }
 
+export interface MapContextLayerMvt extends MapContextBaseLayer {
+  type: "mvt";
+  url: string;
+  accessToken?: string;
+}
+
 export interface MapContextLayerXyz extends MapContextBaseLayer {
   type: "xyz";
   url: string;
@@ -94,7 +100,8 @@ export type MapContextLayer =
   | MapContextLayerXyz
   | MapContextLayerGeojson
   | MapContextLayerOgcApi
-  | MapContextLayerMapLibreStyle;
+  | MapContextLayerMapLibreStyle
+  | MapContextLayerMvt;
 
 export type Coordinate = [number, number];
 

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -61,15 +61,10 @@ export interface MapContextLayerMapLibreStyle extends MapContextBaseLayer {
   accessToken?: string;
 }
 
-export interface MapContextLayerMvt extends MapContextBaseLayer {
-  type: "mvt";
-  url: string;
-  accessToken?: string;
-}
-
 export interface MapContextLayerXyz extends MapContextBaseLayer {
   type: "xyz";
   url: string;
+  tileFormat?: string;
 }
 
 interface LayerGeojson extends MapContextBaseLayer {
@@ -100,8 +95,7 @@ export type MapContextLayer =
   | MapContextLayerXyz
   | MapContextLayerGeojson
   | MapContextLayerOgcApi
-  | MapContextLayerMapLibreStyle
-  | MapContextLayerMvt;
+  | MapContextLayerMapLibreStyle;
 
 export type Coordinate = [number, number];
 

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -13,6 +13,7 @@ import {
   MAP_CTX_LAYER_GEOJSON_FIXTURE,
   MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE,
   MAP_CTX_LAYER_MAPBLIBRE_STYLE_FIXTURE,
+  MAP_CTX_LAYER_MVT_FIXTURE,
   MAP_CTX_LAYER_OGCAPI_FIXTURE,
   MAP_CTX_LAYER_WFS_FIXTURE,
   MAP_CTX_LAYER_WMS_FIXTURE,
@@ -42,6 +43,7 @@ import {
 } from "./handle-errors";
 import { ImageTile } from "ol";
 import TileState from "ol/TileState.js";
+import VectorTileLayer from "ol/layer/VectorTile";
 
 vi.mock("./handle-errors", async (importOriginal) => {
   const actual = await importOriginal();
@@ -392,6 +394,26 @@ describe("MapContextService", () => {
       it("create a Vector Tile source", () => {
         const source = layer.getSource();
         expect(source).toBeInstanceOf(VectorTile);
+      });
+    });
+
+    describe("MVT", () => {
+      beforeEach(async () => {
+        (layerModel = MAP_CTX_LAYER_MVT_FIXTURE),
+          (layer = await createLayer(layerModel));
+      });
+      it("create a VectorTileLayer", () => {
+        expect(layer).toBeTruthy();
+        expect(layer).toBeInstanceOf(VectorTileLayer);
+      });
+      it("create a VectorTile source", () => {
+        const source = layer.getSource();
+        expect(source).toBeInstanceOf(VectorTile);
+      });
+      it("set correct layer properties", () => {
+        expect(layer.getVisible()).toBe(true);
+        expect(layer.getOpacity()).toBe(1);
+        expect(layer.get("label")).toBeUndefined();
       });
     });
   });

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -35,6 +35,7 @@ import {
   handleEndpointError,
   tileLoadErrorCatchFunction,
 } from "./handle-errors";
+import VectorTile from "ol/source/VectorTile";
 
 const GEOJSON = new GeoJSON();
 const WFS_MAX_FEATURES = 10000;
@@ -152,6 +153,17 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
         styleUrl: layerModel.styleUrl,
         accessToken: layerModel.accessToken,
       }) as unknown as Layer;
+      break;
+    }
+    case "mvt": {
+      const url = layerModel.url.replace(/\/?$/, "/{z}/{x}/{y}.pbf");
+      layer = new VectorTileLayer({
+        source: new VectorTile({
+          format: new MVT(),
+          url,
+          attributions: layerModel.attributions,
+        }),
+      });
       break;
     }
     case "geojson": {

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -46,12 +46,11 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
   switch (type) {
     case "xyz":
       {
-        if (layerModel.tileFormat === "mvt") {
-          const url = layerModel.url.replace(/\/?$/, "/{z}/{x}/{y}.pbf");
+        if (layerModel.tileFormat === "application/vnd.mapbox-vector-tile") {
           layer = new VectorTileLayer({
             source: new VectorTile({
               format: new MVT(),
-              url,
+              url: layerModel.url,
               attributions: layerModel.attributions,
             }),
           });


### PR DESCRIPTION
PR adds a new vector tile layer type `mvt` that allows to display vector TMS without style in OL's blue default style.