### PR TITLE
Style par defaut pour une couche WMTS...

### DIFF
--- a/apps/examples/src/examples/Example-ZoomToLayer.vue
+++ b/apps/examples/src/examples/Example-ZoomToLayer.vue
@@ -21,8 +21,8 @@ const Layers = {
   } as MapContextLayerWms,
   wmts: {
     type: 'wmts',
-    url: 'https://map.bern.ch/arcgis/rest/services/Geoportal/Hist_Bern_1872/MapServer/WMTS/1.0.0/WMTSCapabilities.xml',
-    name: 'Geoportal_Hist_Bern_1872'
+    url: 'https://data.geopf.fr/wmts?SERVICE=WMTS&Request=GetCapabilities&Version=1.0.0',
+    name: 'BUILDINGS.BUILDINGS'
   } as MapContextLayerWmts,
   geojson: {
     type: 'geojson',

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -113,7 +113,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
           olLayer.setSource(
             new WMTS({
               layer: layer.name,
-              style: layer.defaultStyle,
+              style: layer.defaultStyle || layer.styles[0].name,
               matrixSet: matrixSet.identifier,
               format: resourceUrl.format,
               url: resourceUrl.url,


### PR DESCRIPTION
Dans la norme _OGC_, le paramètre **style** est obligatoire dans la requête _GetTile_ du _WMTS_ (ttps://www.ogc.org/standards/wmts/ ).

Il faut donc toujours proposer un style pour le _WMTS_

- soit le **GetCapabilities** nous fournit l'information du style par défaut dans sa liste (attribut `isDefault`)
- soit on choisie aléatoirement un style dans la liste (par convention, le 1er de la liste)