### PR TITLE
Add type import geometry for index.ts

### DIFF
--- a/packages/geocoding/lib/model/index.ts
+++ b/packages/geocoding/lib/model/index.ts
@@ -1,4 +1,4 @@
-import { Geometry } from "geojson";
+import { type Geometry } from "geojson";
 
 export interface GeocodingResult {
   label: string;


### PR DESCRIPTION
This resolves an issue when using the package and having the tsconfig `"verbatimModuleSyntax": true`