### PR TITLE
Add optional image format property to WMS layers

### DIFF
--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -97,6 +97,13 @@ export interface MapContextLayerWms extends MapContextBaseLayer {
    * Default value: `true` (use tiled requests)
    */
   useTiles?: boolean;
+
+  /**
+   * The image format to use for WMS requests, e.g. `"image/png"` or `"image/jpeg"`.
+   *
+   * If not specified, the WMS server's default format will be used.
+   */
+  format?: string;
 }
 
 export interface MapContextLayerWmts extends MapContextBaseLayer {

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -99,7 +99,7 @@ export interface MapContextLayerWms extends MapContextBaseLayer {
   useTiles?: boolean;
 
   /**
-   * The image format to use for WMS requests, e.g. `"image/png"` or `"image/jpeg"`.
+   * The image format MIME type to use for WMS requests, e.g. `"image/png"` or `"image/jpeg"`.
    *
    * If not specified, the WMS server's default format will be used.
    */

--- a/packages/maplibre/lib/map/create-map.test.ts
+++ b/packages/maplibre/lib/map/create-map.test.ts
@@ -49,6 +49,14 @@ describe("MapContextService", () => {
           "https://www.datagrandest.fr/geoserver/region-grand-est/ows?REQUEST=GetMap&SERVICE=WMS&layers=commune_actuelle_3857&styles=&format=image%2Fpng&transparent=true&version=1.1.1&height=256&width=256&srs=EPSG%3A3857&BBOX={bbox-epsg-3857}",
         ]);
       });
+      it("uses the provided WMS output format", async () => {
+        layerModel = { ...MAP_CTX_LAYER_WMS_FIXTURE, format: "image/jpeg" };
+        style = (await createLayer(layerModel)) as PartialStyleSpecification;
+        const source = style.sources["123456"] as RasterSourceSpecification;
+        expect(source.tiles).toEqual([
+          "https://www.datagrandest.fr/geoserver/region-grand-est/ows?REQUEST=GetMap&SERVICE=WMS&layers=commune_actuelle_3857&styles=&format=image%2Fjpeg&transparent=true&version=1.1.1&height=256&width=256&srs=EPSG%3A3857&BBOX={bbox-epsg-3857}",
+        ]);
+      });
       it("create a layer", () => {
         expect(style.layers).toBeTruthy();
         expect(style.layers.length).toBe(1);

--- a/packages/maplibre/lib/map/create-map.ts
+++ b/packages/maplibre/lib/map/create-map.ts
@@ -50,7 +50,7 @@ export async function createLayer(
         widthPx: 256,
         heightPx: 256,
         extent: [0, 0, 0, 0], // will be replaced by maplibre-gl
-        outputFormat: "image/png",
+        outputFormat: layerModel.format ?? "image/png",
         crs: "EPSG:3857",
       });
       url = removeSearchParams(url, ["bbox"]);

--- a/packages/maplibre/mocks/ogc-client.ts
+++ b/packages/maplibre/mocks/ogc-client.ts
@@ -15,8 +15,10 @@ export class WmsEndpoint {
           latLonBoundingBox: [1.33, 48.81, 4.3, 51.1],
         };
       },
-      getMapUrl: () => {
-        return "https://www.datagrandest.fr/geoserver/region-grand-est/ows?REQUEST=GetMap&SERVICE=WMS&layers=commune_actuelle_3857&styles=&format=image%2Fpng&transparent=true&version=1.1.1&height=256&width=256&srs=EPSG%3A3857&bbox=0%2C0%2C0%2C0";
+      getMapUrl: (_layers, options) => {
+        const outputFormat = options?.outputFormat ?? "image/png";
+        const format = encodeURIComponent(outputFormat);
+        return `https://www.datagrandest.fr/geoserver/region-grand-est/ows?REQUEST=GetMap&SERVICE=WMS&layers=commune_actuelle_3857&styles=&format=${format}&transparent=true&version=1.1.1&height=256&width=256&srs=EPSG%3A3857&bbox=0%2C0%2C0%2C0`;
       },
     });
   }

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -193,6 +193,18 @@ describe("MapContextService", () => {
           TILED: true,
         });
       });
+      it("sets custom WMS FORMAT param when provided", async () => {
+        layerModel = { ...MAP_CTX_LAYER_WMS_FIXTURE, format: "image/jpeg" };
+        layer = await createLayer(layerModel);
+        const source = layer.getSource() as TileWMS;
+        const params = source.getParams();
+        expect(params).toEqual({
+          LAYERS: (layerModel as MapContextLayerWms).name,
+          FORMAT: "image/jpeg",
+          STYLES: (layerModel as MapContextLayerWms).style,
+          TILED: true,
+        });
+      });
       it("set correct url without existing REQUEST and SERVICE params", () => {
         const source = layer.getSource() as TileWMS;
         const urls = source.getUrls() || [];
@@ -263,6 +275,21 @@ describe("MapContextService", () => {
           const params = source.getParams();
           expect(params).toEqual({
             LAYERS: (layerModel as MapContextLayerWms).name,
+            STYLES: (layerModel as MapContextLayerWms).style,
+          });
+        });
+        it("sets custom WMS FORMAT param when provided", async () => {
+          layerModel = {
+            ...MAP_CTX_LAYER_WMS_FIXTURE,
+            useTiles: false,
+            format: "image/jpeg",
+          };
+          layer = await createLayer(layerModel);
+          const source = layer.getSource() as ImageWMS;
+          const params = source.getParams();
+          expect(params).toEqual({
+            LAYERS: (layerModel as MapContextLayerWms).name,
+            FORMAT: "image/jpeg",
             STYLES: (layerModel as MapContextLayerWms).style,
           });
         });

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -104,6 +104,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
         const url = removeSearchParams(layerModel.url, ["request", "service"]);
         const params = {
           LAYERS: layerModel.name,
+          ...(layerModel.format && { FORMAT: layerModel.format }),
           ...(layerModel.style && { STYLES: layerModel.style }),
         };
         if (layerModel.useTiles === false) {


### PR DESCRIPTION
### Description

Adds an optional `format` property to `MapContextLayerWms` to allow
consumers to control the WMS image format (e.g. `image/png`, `image/jpeg`).