### PR TITLE
Referrer policy

### DIFF
--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -76,6 +76,14 @@ export interface MapContextBaseLayer {
    * Default value is `false`.
    */
   hoverable?: boolean;
+
+  /**
+   * Controls the `Referer` header sent with tile/image requests.
+   * See the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Request/referrerPolicy) for possible values.
+   *
+   * Support depends on the layer type and the map library used.
+   */
+  referrerPolicy?: ReferrerPolicy;
 }
 
 export interface MapContextLayerWms extends MapContextBaseLayer {

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -112,6 +112,17 @@ describe("MapContextService", () => {
         tileLoadFunction(tile, "http://example.com/tile");
         expect(tileLoadErrorCatchFunction).toHaveBeenCalled();
       });
+      it("should configure XYZ source with referrerPolicy from layer model", async () => {
+        const layerWithPolicy = await createLayer({
+          ...MAP_CTX_LAYER_XYZ_FIXTURE,
+          referrerPolicy: "strict-origin-when-cross-origin",
+        });
+        const source = layerWithPolicy.getSource() as XYZ;
+        // referrerPolicy is protected on TileImage; access via bracket to verify it is set
+        expect(
+          (source as unknown as Record<string, unknown>)["referrerPolicy"],
+        ).toBe("strict-origin-when-cross-origin");
+      });
       it("emits a loaded event initially", async () => {
         await vi.runAllTimersAsync();
         expect(eventCallback).toHaveBeenCalledWith({
@@ -232,6 +243,7 @@ describe("MapContextService", () => {
         tileLoadFunction(tile, "http://example.com/tile");
         expect(tileLoadErrorCatchFunction).toHaveBeenCalled();
       });
+
       it("emits a loaded event initially", async () => {
         await vi.runAllTimersAsync();
         expect(eventCallback).toHaveBeenCalledWith({

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -84,6 +84,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
           layer = new TileLayer({});
           const source = new XYZ({
             url: layerModel.url,
+            referrerPolicy: layerModel.referrerPolicy,
             attributions: layerModel.attributions,
           });
           source.setTileLoadFunction(function (tile: Tile, src: string) {
@@ -112,6 +113,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
             source: new ImageWMS({
               url,
               params,
+              referrerPolicy: layerModel.referrerPolicy,
               attributions: layerModel.attributions,
             }),
           });
@@ -160,6 +162,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
               format: resourceUrl.format,
               url: resourceUrl.url,
               requestEncoding: resourceUrl.encoding,
+              referrerPolicy: layerModel.referrerPolicy,
               tileGrid,
               projection: matrixSet.crs,
               dimensions,

--- a/packages/openlayers/lib/map/handle-errors.test.ts
+++ b/packages/openlayers/lib/map/handle-errors.test.ts
@@ -1,11 +1,15 @@
+import ImageTile from "ol/ImageTile.js";
 import TileLayer from "ol/layer/Tile.js";
+import TileState from "ol/TileState.js";
 import VectorLayer from "ol/layer/Vector.js";
 import { emitLayerLoadingError } from "./register-events.js";
+import { tileLoadErrorCatchFunction } from "./handle-errors.js";
 
 globalThis.URL.createObjectURL = vi.fn(() => "blob:http://example.com/blob");
 
 const mockBlob = new Blob();
 const RESPONSE_OK = {
+  ok: true,
   status: 200,
   blob: vi.fn().mockResolvedValue(mockBlob),
 };
@@ -19,6 +23,55 @@ globalThis.fetch = vi.fn().mockImplementation((url: string) => {
 });
 
 describe("handle-errors", () => {
+  describe("tileLoadErrorCatchFunction", () => {
+    let layer: TileLayer<never>;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+      layer = new TileLayer({});
+    });
+
+    it("should call fetch with referrerPolicy from the tile when set", () => {
+      const tile = new ImageTile(
+        [0, 0, 0],
+        TileState.IDLE,
+        "http://example.com/tile",
+        { referrerPolicy: "strict-origin-when-cross-origin" },
+        () => {},
+      );
+      tileLoadErrorCatchFunction(layer, tile, "http://example.com/tile");
+      expect(fetch).toHaveBeenCalledWith("http://example.com/tile", {
+        referrerPolicy: "strict-origin-when-cross-origin",
+      });
+    });
+
+    it("should call fetch without referrerPolicy when tile has none", () => {
+      const tile = new ImageTile(
+        [0, 0, 0],
+        TileState.IDLE,
+        "http://example.com/tile",
+        null,
+        () => {},
+      );
+      tileLoadErrorCatchFunction(layer, tile, "http://example.com/tile");
+      expect(fetch).toHaveBeenCalledWith("http://example.com/tile", {});
+    });
+
+    it("should set tile state to ERROR on fetch rejection", async () => {
+      const tile = new ImageTile(
+        [0, 0, 0],
+        TileState.IDLE,
+        "http://example.com/error",
+        null,
+        () => {},
+      );
+      const setStateSpy = vi.spyOn(tile, "setState");
+      tileLoadErrorCatchFunction(layer, tile, "http://example.com/error");
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(setStateSpy).toHaveBeenCalledWith(TileState.ERROR);
+    });
+  });
   describe("handleEndpointError", () => {
     it("should dispatch SourceLoadErrorEvent", () => {
       const layer = new VectorLayer({});

--- a/packages/openlayers/lib/map/handle-errors.ts
+++ b/packages/openlayers/lib/map/handle-errors.ts
@@ -8,7 +8,11 @@ export function tileLoadErrorCatchFunction(
   tile: Tile,
   src: string,
 ) {
-  fetch(src)
+  const referrerPolicy =
+    "getReferrerPolicy" in tile
+      ? (tile as ImageTile).getReferrerPolicy()
+      : undefined;
+  fetch(src, { ...(referrerPolicy && { referrerPolicy }) })
     .then((response) => {
       if (response.ok) {
         response


### PR DESCRIPTION
Add optional referrerPolicy to layer models.

I didn't handled the case the property is passed but not supported, I suppose it will be ignored by OpenLayers (tested against 10.7.0, didn't get any error, just 403 from OSM).

Pretty sure I added referrerPolicy everywhere it is actually supported on OL side.