### PR TITLE
fix(openlayers): handle errors on OGC API layer load

### DIFF
--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -179,9 +179,7 @@ describe("MapContextService", () => {
         vi.spyOn(
           OgcApiEndpoint.prototype,
           "getCollectionItemsUrl",
-        ).mockImplementation(() => {
-          throw new Error("Failed to load collection");
-        });
+        ).mockRejectedValue(new Error("Failed to load collection"));
         layerModel = MAP_CTX_LAYER_OGCAPI_FIXTURE;
         layer = await createLayer(layerModel);
         layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-error`, eventCallback);

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -48,6 +48,7 @@ import { tileLoadErrorCatchFunction } from "./handle-errors.js";
 import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
 import ImageLayer from "ol/layer/Image.js";
 import ImageWMS from "ol/source/ImageWMS.js";
+import { OgcApiEndpoint } from "@camptocamp/ogc-client";
 
 vi.mock("./handle-errors", async (importOriginal) => {
   const actual =
@@ -171,6 +172,39 @@ describe("MapContextService", () => {
           target: layer,
           type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
         });
+      });
+    });
+    describe("OGCAPI (with failing endpoint)", () => {
+      beforeEach(async () => {
+        vi.spyOn(
+          OgcApiEndpoint.prototype,
+          "getCollectionItemsUrl",
+        ).mockImplementation(() => {
+          throw new Error("Failed to load collection");
+        });
+        layerModel = MAP_CTX_LAYER_OGCAPI_FIXTURE;
+        layer = await createLayer(layerModel);
+        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-error`, eventCallback);
+      });
+
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it("creates an empty vector layer", () => {
+        expect(layer).toBeInstanceOf(VectorLayer);
+        expect(layer.getSource()).toBeNull();
+      });
+
+      it("emits a loading error event", async () => {
+        await vi.runAllTimersAsync();
+        expect(eventCallback).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
+            error: expect.any(Error),
+            target: layer,
+          }),
+        );
       });
     });
     describe("WMS", () => {

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -306,7 +306,20 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
         }
         defer().then(() => emitLayerLoadingStatusSuccess(layer));
       } catch (e) {
-        layer = new VectorLayer({ style: layerModel.style ?? defaultStyle });
+        if (layerModel.useTiles === "vector") {
+          layer = new VectorTileLayer({
+            properties: { [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true },
+          });
+        } else if (layerModel.useTiles === "map") {
+          layer = new TileLayer({
+            properties: { [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true },
+          });
+        } else {
+          layer = new VectorLayer({
+            style: layerModel.style ?? defaultStyle,
+            properties: { [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true },
+          });
+        }
         const httpStatus =
           e instanceof EndpointError ? e.httpStatus : undefined;
         const err = e instanceof Error ? e : new Error(String(e));

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -264,48 +264,54 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
     case "ogcapi": {
       const ogcEndpoint = new OgcApiEndpoint(layerModel.url);
       let layerUrl: string;
-      if (layerModel.useTiles) {
-        if (layerModel.useTiles === "vector") {
-          layerUrl = await ogcEndpoint.getVectorTilesetUrl(
+      try {
+        if (layerModel.useTiles) {
+          if (layerModel.useTiles === "vector") {
+            layerUrl = await ogcEndpoint.getVectorTilesetUrl(
+              layerModel.collection,
+              layerModel.tileMatrixSet,
+            );
+            layer = new VectorTileLayer({
+              source: new OGCVectorTile({
+                url: layerUrl,
+                format: new MVT(),
+                attributions: layerModel.attributions,
+              }),
+            });
+          } else if (layerModel.useTiles === "map") {
+            layerUrl = await ogcEndpoint.getMapTilesetUrl(
+              layerModel.collection,
+              layerModel.tileMatrixSet,
+            );
+            layer = new TileLayer({
+              source: new OGCMapTile({
+                url: layerUrl,
+                attributions: layerModel.attributions,
+              }),
+            });
+          }
+        } else {
+          layerUrl = await ogcEndpoint.getCollectionItemsUrl(
             layerModel.collection,
-            layerModel.tileMatrixSet,
+            layerModel.options,
           );
-          layer = new VectorTileLayer({
-            source: new OGCVectorTile({
+          layer = new VectorLayer({
+            source: new VectorSource({
+              format: new GeoJSON(),
               url: layerUrl,
-              format: new MVT(),
               attributions: layerModel.attributions,
             }),
-          });
-        } else if (layerModel.useTiles === "map") {
-          layerUrl = await ogcEndpoint.getMapTilesetUrl(
-            layerModel.collection,
-            layerModel.tileMatrixSet,
-          );
-          layer = new TileLayer({
-            source: new OGCMapTile({
-              url: layerUrl,
-              attributions: layerModel.attributions,
-            }),
+            style: layerModel.style ?? defaultStyle,
           });
         }
-      } else {
-        layerUrl = await ogcEndpoint.getCollectionItemsUrl(
-          layerModel.collection,
-          layerModel.options,
-        );
-        const source = new VectorSource({
-          format: new GeoJSON(),
-          url: layerUrl,
-          attributions: layerModel.attributions,
-        });
-        layer = new VectorLayer({
-          source,
-          style: layerModel.style ?? defaultStyle,
-        });
+        defer().then(() => emitLayerLoadingStatusSuccess(layer));
+      } catch (e) {
+        layer = new VectorLayer({ style: layerModel.style ?? defaultStyle });
+        const httpStatus =
+          e instanceof EndpointError ? e.httpStatus : undefined;
+        const err = e instanceof Error ? e : new Error(String(e));
+        defer().then(() => emitLayerLoadingError(layer, err, httpStatus));
       }
-      // FIXME: actually track layer loading
-      defer().then(() => emitLayerLoadingStatusSuccess(layer));
       break;
     }
 

--- a/packages/openlayers/mocks/ogc-client.ts
+++ b/packages/openlayers/mocks/ogc-client.ts
@@ -149,4 +149,14 @@ export class OgcApiEndpoint {
   getCollectionItemsUrl(collection) {
     return "https://demo.ldproxy.net/zoomstack/collections/airports/items?f=json";
   }
+  getVectorTilesetUrl(collection, tileMatrixSet) {
+    return Promise.resolve(
+      "https://demo.ldproxy.net/zoomstack/collections/airports/tiles/WebMercatorQuad",
+    );
+  }
+  getMapTilesetUrl(collection, tileMatrixSet) {
+    return Promise.resolve(
+      "https://demo.ldproxy.net/zoomstack/collections/airports/map/tiles/WebMercatorQuad",
+    );
+  }
 }


### PR DESCRIPTION
Refactor create-map to catch and propagate errors when loading OGC API layers, and add unit tests covering error scenarios.