### PR TITLE
Handle and emit GeoJSON layer errors

### DIFF
--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -511,15 +511,41 @@ describe("MapContextService", () => {
             (layerModel as MapContextLayerGeojson).url,
           );
         });
-        it("emits a loaded event as well as data info eventually", async () => {
-          await vi.runAllTimersAsync();
+        it("emits a loaded event when features load", () => {
+          const source = layer.getSource() as VectorSource;
+          source.dispatchEvent("featuresloadend");
           expect(eventCallback).toHaveBeenCalledWith({
-            layerState: {
-              loaded: true,
-            },
+            layerState: { loaded: true },
             target: layer,
             type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
           });
+        });
+      });
+      describe("with remote file url (failing to load)", () => {
+        beforeEach(async () => {
+          layerModel = MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE;
+          layer = await createLayer(layerModel);
+          layer.on(
+            `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
+            eventCallback,
+          );
+        });
+        it("creates a vector layer with an empty source", () => {
+          const source = layer.getSource() as VectorSource;
+          expect(layer).toBeInstanceOf(VectorLayer);
+          expect(source).toBeInstanceOf(VectorSource);
+          expect(source.getFeatures().length).toBe(0);
+        });
+        it("emits a loading error event when features fail to load", () => {
+          const source = layer.getSource() as VectorSource;
+          source.dispatchEvent("featuresloaderror");
+          expect(eventCallback).toHaveBeenCalledWith(
+            expect.objectContaining({
+              type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
+              error: expect.any(Error),
+              target: layer,
+            }),
+          );
         });
       });
     });

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -469,6 +469,10 @@ describe("MapContextService", () => {
             data: "blargz",
           };
           layer = await createLayer(layerModel);
+          layer.on(
+            `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
+            eventCallback,
+          );
         });
         it("create a VectorLayer", () => {
           expect(layer).toBeTruthy();
@@ -481,6 +485,16 @@ describe("MapContextService", () => {
           const source = layer.getSource() as VectorSource;
           expect(source).toBeInstanceOf(VectorSource);
           expect(source.getFeatures().length).toBe(0);
+        });
+        it("emits a loading error event", async () => {
+          await vi.runAllTimersAsync();
+          expect(eventCallback).toHaveBeenCalledWith(
+            expect.objectContaining({
+              type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
+              error: expect.any(Error),
+              target: layer,
+            }),
+          );
         });
       });
       describe("with remote file url", () => {

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -236,6 +236,17 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
           url: layerModel.url,
           attributions: layerModel.attributions,
         });
+        source.once("featuresloadend", () =>
+          emitLayerLoadingStatusSuccess(layer),
+        );
+        source.once("featuresloaderror", () =>
+          emitLayerLoadingError(
+            layer,
+            new Error(
+              `GeoJSON features could not be loaded from: ${layerModel.url}`,
+            ),
+          ),
+        );
       } else {
         let geojson = layerModel.data;
         if (typeof geojson === "string") {
@@ -254,10 +265,9 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
           features,
           attributions: layerModel.attributions,
         });
+        defer().then(() => emitLayerLoadingStatusSuccess(layer));
       }
       layer.setSource(source);
-      // FIXME: actually track layer loading and data info
-      defer().then(() => emitLayerLoadingStatusSuccess(layer));
       break;
     }
 

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -249,23 +249,32 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
         );
       } else {
         let geojson = layerModel.data;
-        if (typeof geojson === "string") {
-          try {
+        try {
+          if (typeof geojson === "string") {
             geojson = JSON.parse(geojson);
-          } catch (e) {
-            console.warn("A layer could not be created", layerModel, e);
-            geojson = { type: "FeatureCollection", features: [] };
           }
+          const features = GEOJSON.readFeatures(geojson, {
+            featureProjection: "EPSG:3857",
+            dataProjection: "EPSG:4326",
+          }) as Feature<Geometry>[];
+          source = new VectorSource({
+            features,
+            attributions: layerModel.attributions,
+          });
+          defer().then(() => emitLayerLoadingStatusSuccess(layer));
+        } catch (e) {
+          console.warn(
+            "GeoJSON layer data could not be parsed/read",
+            layerModel,
+            e,
+          );
+          source = new VectorSource({
+            features: [],
+            attributions: layerModel.attributions,
+          });
+          const err = e instanceof Error ? e : new Error(String(e));
+          defer().then(() => emitLayerLoadingError(layer, err));
         }
-        const features = GEOJSON.readFeatures(geojson, {
-          featureProjection: "EPSG:3857",
-          dataProjection: "EPSG:4326",
-        }) as Feature<Geometry>[];
-        source = new VectorSource({
-          features,
-          attributions: layerModel.attributions,
-        });
-        defer().then(() => emitLayerLoadingStatusSuccess(layer));
       }
       layer.setSource(source);
       break;


### PR DESCRIPTION
Previously, errors occurring during GeoJSON layer loading were silently swallowed, leaving the map without any feedback.

**URL-based GeoJSON layers** — the `featuresloaderror` event from the `VectorSource` is now caught and forwarded as a `layer-loading-error` event on the layer, consistent with the error handling of other layer types (WMS, WMTS, OGC API…).

**Inline GeoJSON layers** — `JSON.parse` and `GEOJSON.readFeatures` are now wrapped in a single try/catch. On failure, a `layer-loading-error` event is emitted (previously only a `console.warn` was issued). On success, `layer-loading-status` (loaded) is emitted from inside the try block.
