### PR TITLE
refactor(legend): data-first API

### DIFF
--- a/packages/legend/README.md
+++ b/packages/legend/README.md
@@ -2,7 +2,9 @@
 
 <!-- #region body -->
 
-This package provides utilities to automatically create map legends from layer definitions in a Map Context.
+This package derives map legends from layer definitions in a Map Context. It is framework-agnostic: it returns data (legend URLs and entries) and leaves rendering to the consumer.
+
+Legends are currently supported for **WMS** and **WMTS** layers.
 
 ## Installation
 
@@ -13,17 +15,40 @@ npm install @geospatial-sdk/legend
 ## Usage
 
 ```typescript
-import { createLegendFromLayer } from "@geospatial-sdk/legend";
+import {
+  hasLegendSupport,
+  createLegendUrlFromLayer,
+  createLegendEntriesFromLayer,
+  createLegendFromLayer,
+} from "@geospatial-sdk/legend";
+import type { MapContextLayerWms } from "@geospatial-sdk/core";
 
-const layer = {
+const layer: MapContextLayerWms = {
   type: "wms",
   url: "https://example.com/wms",
   name: "test-layer",
 };
 
-createLegendFromLayer(layer).then((legendDiv) => {
-  document.body.appendChild(legendDiv);
-});
+// Cheap, type-level guard — use it to gate UI (e.g. enable a "legend" tab).
+hasLegendSupport(layer); // => true
+
+// Resolve the raster legend graphic URL.
+const url = await createLegendUrlFromLayer(layer);
+
+// Build the list of legend entries and render them however you like.
+const entries = await createLegendEntriesFromLayer(layer);
+for (const entry of entries) {
+  const img = document.createElement("img");
+  img.src = entry.url;
+  img.alt = entry.label;
+  document.body.appendChild(img);
+}
+
+// DEPRECATED: build a ready-made legend element with the default CSS classes.
+const legendEl = await createLegendFromLayer(layer);
+if (legendEl) {
+  document.body.appendChild(legendEl);
+}
 ```
 
 <!-- #endregion body -->

--- a/packages/legend/lib/create-legend/from-layer.test.ts
+++ b/packages/legend/lib/create-legend/from-layer.test.ts
@@ -9,10 +9,13 @@ import {
   MapContextLayerWms,
   MapContextLayerWmts,
 } from "@geospatial-sdk/core";
-import { WmtsEndpoint } from "@camptocamp/ogc-client";
+import { WmsEndpoint, WmtsEndpoint } from "@camptocamp/ogc-client";
 
 // Mock dependencies
 vi.mock("@camptocamp/ogc-client", () => ({
+  WmsEndpoint: class WmsMock {
+    isReady() {}
+  },
   WmtsEndpoint: class WmtsMock {
     isReady() {}
   },
@@ -38,8 +41,18 @@ describe("legend", () => {
     vi.spyOn(WmtsEndpoint.prototype, "isReady").mockResolvedValue(endpoint);
   }
 
+  function mockWmsLayer(styles: unknown[]) {
+    const endpoint = {
+      getLayerByName: () => ({ styles }),
+    } as unknown as WmsEndpoint;
+    vi.spyOn(WmsEndpoint.prototype, "isReady").mockResolvedValue(endpoint);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    // WMS resolution reads capabilities; default to a layer with no advertised
+    // legend so the GetLegendGraphic fallback is exercised unless a test overrides.
+    mockWmsLayer([]);
   });
 
   describe("hasLegendSupport", () => {
@@ -105,6 +118,41 @@ describe("legend", () => {
       });
 
       expect(url).not.toContain("STYLE=");
+    });
+
+    it("returns the advertised WMS LegendURL when capabilities declare one", async () => {
+      mockWmsLayer([
+        { name: "default", legendUrl: "https://example.com/wms-legend.png" },
+      ]);
+
+      const url = await createLegendUrlFromLayer(baseWmsLayer);
+
+      expect(url).toBe("https://example.com/wms-legend.png");
+    });
+
+    it("uses the matching WMS style's LegendURL when layer.style is set", async () => {
+      mockWmsLayer([
+        { name: "default", legendUrl: "https://example.com/wms-default.png" },
+        { name: "night", legendUrl: "https://example.com/wms-night.png" },
+      ]);
+
+      const url = await createLegendUrlFromLayer({
+        ...baseWmsLayer,
+        style: "night",
+      });
+
+      expect(url).toBe("https://example.com/wms-night.png");
+    });
+
+    it("falls back to GetLegendGraphic when the WMS capabilities cannot be read", async () => {
+      vi.spyOn(WmsEndpoint.prototype, "isReady").mockRejectedValue(
+        new Error("capabilities unreachable"),
+      );
+
+      const url = await createLegendUrlFromLayer(baseWmsLayer);
+
+      expect(url).toContain("REQUEST=GetLegendGraphic");
+      expect(url).toContain("LAYER=test-layer");
     });
 
     it("resolves a WMTS legend URL", async () => {

--- a/packages/legend/lib/create-legend/from-layer.test.ts
+++ b/packages/legend/lib/create-legend/from-layer.test.ts
@@ -151,6 +151,17 @@ describe("legend", () => {
       ).rejects.toThrow(/missing url or name/);
     });
 
+    it("throws when the WMTS layer is not found in the capabilities", async () => {
+      const endpoint = {
+        getLayerByName: () => null,
+      } as unknown as WmtsEndpoint;
+      vi.spyOn(WmtsEndpoint.prototype, "isReady").mockResolvedValue(endpoint);
+
+      await expect(createLegendUrlFromLayer(baseWmtsLayer)).rejects.toThrow(
+        /was not found/,
+      );
+    });
+
     it("propagates a failing WMTS endpoint", async () => {
       vi.spyOn(WmtsEndpoint.prototype, "isReady").mockRejectedValue(
         new Error("capabilities unreachable"),

--- a/packages/legend/lib/create-legend/from-layer.test.ts
+++ b/packages/legend/lib/create-legend/from-layer.test.ts
@@ -216,6 +216,7 @@ describe("legend", () => {
 
       expect(el).toBeInstanceOf(HTMLElement);
       expect(el?.getAttribute("role")).toBe("region");
+      expect(el?.getAttribute("aria-label")).toBe("Map Layer Legend");
       expect(el?.querySelector("h4")?.textContent).toBe("test-layer");
       const img = el?.querySelector("img");
       expect(img?.alt).toBe("Legend for test-layer");

--- a/packages/legend/lib/create-legend/from-layer.test.ts
+++ b/packages/legend/lib/create-legend/from-layer.test.ts
@@ -178,6 +178,7 @@ describe("legend", () => {
       const entries = await createLegendEntriesFromLayer(baseWmsLayer);
 
       expect(entries).toHaveLength(1);
+      expect(entries[0].type).toBe("image");
       expect(entries[0].label).toBe("test-layer");
       expect(entries[0].url).toContain("REQUEST=GetLegendGraphic");
     });

--- a/packages/legend/lib/create-legend/from-layer.test.ts
+++ b/packages/legend/lib/create-legend/from-layer.test.ts
@@ -99,7 +99,10 @@ describe("legend", () => {
     });
 
     it("omits the STYLE parameter when the style is an empty string", async () => {
-      const url = await createLegendUrlFromLayer({ ...baseWmsLayer, style: "" });
+      const url = await createLegendUrlFromLayer({
+        ...baseWmsLayer,
+        style: "",
+      });
 
       expect(url).not.toContain("STYLE=");
     });

--- a/packages/legend/lib/create-legend/from-layer.test.ts
+++ b/packages/legend/lib/create-legend/from-layer.test.ts
@@ -1,5 +1,14 @@
-import { createLegendFromLayer } from "./from-layer.js";
-import { MapContextLayerWms, MapContextLayerWmts } from "@geospatial-sdk/core";
+import {
+  createLegendEntriesFromLayer,
+  createLegendFromLayer,
+  createLegendUrlFromLayer,
+  hasLegendSupport,
+} from "./from-layer.js";
+import {
+  MapContextLayer,
+  MapContextLayerWms,
+  MapContextLayerWmts,
+} from "@geospatial-sdk/core";
 import { WmtsEndpoint } from "@camptocamp/ogc-client";
 
 // Mock dependencies
@@ -9,7 +18,7 @@ vi.mock("@camptocamp/ogc-client", () => ({
   },
 }));
 
-describe("createLegendFromLayer", () => {
+describe("legend", () => {
   const baseWmsLayer: MapContextLayerWms = {
     type: "wms",
     url: "https://example.com/wms",
@@ -22,162 +31,216 @@ describe("createLegendFromLayer", () => {
     name: "test-wmts-layer",
   };
 
+  function mockWmtsLayer(styles: unknown[]) {
+    const endpoint = {
+      getLayerByName: () => ({ styles }),
+    } as unknown as WmtsEndpoint;
+    vi.spyOn(WmtsEndpoint.prototype, "isReady").mockResolvedValue(endpoint);
+  }
+
   beforeEach(() => {
-    // Clear all mocks before each test
     vi.clearAllMocks();
   });
 
-  it("creates a legend for a valid WMS layer", async () => {
-    const result = await createLegendFromLayer(baseWmsLayer);
-
-    expect(result).toBeInstanceOf(HTMLElement);
-
-    const legendDiv = result as HTMLElement;
-    const img = legendDiv.querySelector("img");
-    const title = legendDiv.querySelector("h4");
-
-    expect(title?.textContent).toBe("test-layer");
-    expect(img).toBeTruthy();
-    expect(img?.src).toContain("REQUEST=GetLegendGraphic");
-    expect(img?.alt).toBe("Legend for test-layer");
-  });
-
-  it("creates a legend for a valid WMS layer with custom options", async () => {
-    const result = await createLegendFromLayer(baseWmsLayer, {
-      format: "image/jpeg",
-      widthPxHint: 200,
-      heightPxHint: 100,
+  describe("hasLegendSupport", () => {
+    it("returns true for a WMS layer with url and name", () => {
+      expect(hasLegendSupport(baseWmsLayer)).toBe(true);
     });
 
-    const img = (result as HTMLElement).querySelector("img");
-
-    expect(img?.src).toContain("FORMAT=image%2Fjpeg");
-    expect(img?.src).toContain("WIDTH=200");
-    expect(img?.src).toContain("HEIGHT=100");
-  });
-
-  it("includes STYLE parameter in WMS legend URL when layer has a style", async () => {
-    const result = await createLegendFromLayer({
-      ...baseWmsLayer,
-      style: "my_custom_style",
+    it("returns true for a WMTS layer with url and name", () => {
+      expect(hasLegendSupport(baseWmtsLayer)).toBe(true);
     });
 
-    const img = (result as HTMLElement).querySelector("img");
-
-    expect(img?.src).toContain("STYLE=my_custom_style");
-  });
-
-  it("creates a legend for a valid WMTS layer with legend URL", async () => {
-    const mockLegendUrl = "https://example.com/legend.png";
-    const mockIsReady = {
-      getLayerByName: () => ({
-        styles: [{ legendUrl: mockLegendUrl }],
-      }),
-    } as unknown as WmtsEndpoint;
-
-    // Mock WmtsEndpoint
-    vi.spyOn(WmtsEndpoint.prototype, "isReady").mockImplementation(function () {
-      return Promise.resolve(mockIsReady);
+    it("returns false for an unsupported layer type", () => {
+      const geojsonLayer = {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      } as unknown as MapContextLayer;
+      expect(hasLegendSupport(geojsonLayer)).toBe(false);
     });
 
-    const result = await createLegendFromLayer(baseWmtsLayer);
-
-    const img = (result as HTMLElement).querySelector("img");
-
-    expect(img?.src).toBe(mockLegendUrl);
-  });
-
-  it("handles WMTS layer without legend URL", async () => {
-    const mockIsReady = {
-      getLayerByName: () => ({
-        styles: [],
-      }),
-    } as unknown as WmtsEndpoint;
-
-    // Mock WmtsEndpoint
-    vi.spyOn(WmtsEndpoint.prototype, "isReady").mockImplementation(function () {
-      return Promise.resolve(mockIsReady);
+    it("returns false when the url is missing", () => {
+      expect(hasLegendSupport({ ...baseWmsLayer, url: "" })).toBe(false);
     });
 
-    const result = await createLegendFromLayer(baseWmtsLayer);
-
-    const errorSpan = (result as HTMLElement).querySelector("span");
-
-    expect(result).toBeInstanceOf(HTMLElement);
-    expect(errorSpan?.textContent).toBe(
-      "Legend not available for test-wmts-layer",
-    );
+    it("returns false when the name is missing", () => {
+      expect(hasLegendSupport({ ...baseWmsLayer, name: "" })).toBe(false);
+    });
   });
 
-  it("uses matching style legend URL for WMTS layer when layer.style is set", async () => {
-    const mockIsReady = {
-      getLayerByName: () => ({
-        styles: [
-          {
-            name: "default",
-            legendUrl: "https://example.com/default-legend.png",
-          },
-          { name: "night", legendUrl: "https://example.com/night-legend.png" },
-        ],
-      }),
-    } as unknown as WmtsEndpoint;
+  describe("createLegendUrlFromLayer", () => {
+    it("builds a WMS GetLegendGraphic URL", async () => {
+      const url = await createLegendUrlFromLayer(baseWmsLayer);
 
-    vi.spyOn(WmtsEndpoint.prototype, "isReady").mockImplementation(function () {
-      return Promise.resolve(mockIsReady);
+      expect(url).toContain("REQUEST=GetLegendGraphic");
+      expect(url).toContain("SERVICE=WMS");
+      expect(url).toContain("LAYER=test-layer");
     });
 
-    const result = await createLegendFromLayer({
-      ...baseWmtsLayer,
-      style: "night",
+    it("applies custom options", async () => {
+      const url = await createLegendUrlFromLayer(baseWmsLayer, {
+        format: "image/jpeg",
+        widthPxHint: 200,
+        heightPxHint: 100,
+      });
+
+      expect(url).toContain("FORMAT=image%2Fjpeg");
+      expect(url).toContain("WIDTH=200");
+      expect(url).toContain("HEIGHT=100");
     });
-    const img = (result as HTMLElement).querySelector("img");
 
-    expect(img?.src).toBe("https://example.com/night-legend.png");
+    it("includes the STYLE parameter when the layer has a style", async () => {
+      const url = await createLegendUrlFromLayer({
+        ...baseWmsLayer,
+        style: "my_custom_style",
+      });
+
+      expect(url).toContain("STYLE=my_custom_style");
+    });
+
+    it("resolves a WMTS legend URL", async () => {
+      mockWmtsLayer([{ legendUrl: "https://example.com/legend.png" }]);
+
+      const url = await createLegendUrlFromLayer(baseWmtsLayer);
+
+      expect(url).toBe("https://example.com/legend.png");
+    });
+
+    it("uses the matching style legend URL when layer.style is set", async () => {
+      mockWmtsLayer([
+        {
+          name: "default",
+          legendUrl: "https://example.com/default-legend.png",
+        },
+        { name: "night", legendUrl: "https://example.com/night-legend.png" },
+      ]);
+
+      const url = await createLegendUrlFromLayer({
+        ...baseWmtsLayer,
+        style: "night",
+      });
+
+      expect(url).toBe("https://example.com/night-legend.png");
+    });
+
+    it("returns null when a WMTS layer declares no legend", async () => {
+      mockWmtsLayer([]);
+
+      const url = await createLegendUrlFromLayer(baseWmtsLayer);
+
+      expect(url).toBeNull();
+    });
+
+    it("throws for an unsupported layer type", async () => {
+      const invalidLayer = { ...baseWmsLayer, type: "invalid" as never };
+
+      await expect(createLegendUrlFromLayer(invalidLayer)).rejects.toThrow(
+        /type "invalid"/,
+      );
+    });
+
+    it("throws a missing-field error (not a type error) when the url is empty", async () => {
+      await expect(
+        createLegendUrlFromLayer({ ...baseWmsLayer, url: "" }),
+      ).rejects.toThrow(/missing url or name/);
+    });
+
+    it("throws a missing-field error (not a type error) when the name is empty", async () => {
+      await expect(
+        createLegendUrlFromLayer({ ...baseWmsLayer, name: "" }),
+      ).rejects.toThrow(/missing url or name/);
+    });
+
+    it("propagates a failing WMTS endpoint", async () => {
+      vi.spyOn(WmtsEndpoint.prototype, "isReady").mockRejectedValue(
+        new Error("capabilities unreachable"),
+      );
+
+      await expect(createLegendUrlFromLayer(baseWmtsLayer)).rejects.toThrow(
+        "capabilities unreachable",
+      );
+    });
   });
 
-  it("returns null for invalid layer type", async () => {
-    const invalidLayer = { ...baseWmsLayer, type: "invalid" as any };
+  describe("createLegendEntriesFromLayer", () => {
+    it("returns a single image entry for a WMS layer", async () => {
+      const entries = await createLegendEntriesFromLayer(baseWmsLayer);
 
-    const result = await createLegendFromLayer(invalidLayer);
+      expect(entries).toHaveLength(1);
+      expect(entries[0].label).toBe("test-layer");
+      expect(entries[0].url).toContain("REQUEST=GetLegendGraphic");
+    });
 
-    expect(result).toBe(null);
+    it("returns an empty array when the layer has no legend", async () => {
+      mockWmtsLayer([]);
+
+      const entries = await createLegendEntriesFromLayer(baseWmtsLayer);
+
+      expect(entries).toEqual([]);
+    });
+
+    it("accepts a general MapContextLayer and throws for unsupported types", async () => {
+      const geojsonLayer = {
+        type: "geojson",
+        data: { type: "FeatureCollection", features: [] },
+      } as unknown as MapContextLayer;
+
+      // Compiles without a cast: the param accepts the broad MapContextLayer union.
+      await expect(
+        createLegendEntriesFromLayer(geojsonLayer),
+      ).rejects.toThrow();
+    });
   });
 
-  it("returns null for layer without URL", async () => {
-    const layerWithoutUrl = { ...baseWmsLayer, url: "" };
+  describe("createLegendFromLayer (deprecated)", () => {
+    it("builds a legend element with title and image for a WMS layer", async () => {
+      const el = await createLegendFromLayer(baseWmsLayer);
 
-    const result = await createLegendFromLayer(layerWithoutUrl);
+      expect(el).toBeInstanceOf(HTMLElement);
+      expect(el?.getAttribute("role")).toBe("region");
+      expect(el?.querySelector("h4")?.textContent).toBe("test-layer");
+      const img = el?.querySelector("img");
+      expect(img?.alt).toBe("Legend for test-layer");
+      expect(img?.src).toContain("REQUEST=GetLegendGraphic");
+    });
 
-    expect(result).toBe(null);
-  });
+    it("returns null for an unsupported layer type", async () => {
+      const invalidLayer = { ...baseWmsLayer, type: "invalid" as never };
 
-  it("returns null for layer without name", async () => {
-    const layerWithoutName = { ...baseWmsLayer, name: "" };
+      expect(await createLegendFromLayer(invalidLayer)).toBeNull();
+    });
 
-    const result = await createLegendFromLayer(layerWithoutName);
+    it("renders a message when the layer has no legend", async () => {
+      mockWmtsLayer([]);
 
-    expect(result).toBe(null);
-  });
+      const el = await createLegendFromLayer(baseWmtsLayer);
 
-  it("handles image load error", async () => {
-    const result = await createLegendFromLayer(baseWmsLayer);
-    const img = (result as HTMLElement).querySelector("img");
+      expect(el?.querySelector("span")?.textContent).toBe(
+        "Legend not available for test-wmts-layer",
+      );
+    });
 
-    if (img) {
-      const errorEvent = new Event("error");
-      img.dispatchEvent(errorEvent);
+    it("renders an error message when resolving fails", async () => {
+      vi.spyOn(WmtsEndpoint.prototype, "isReady").mockRejectedValue(
+        new Error("capabilities unreachable"),
+      );
 
-      const errorSpan = (result as HTMLElement).querySelector("span");
-      expect(errorSpan?.textContent).toBe(
+      const el = await createLegendFromLayer(baseWmtsLayer);
+
+      expect(el?.querySelector("span")?.textContent).toBe(
+        "Error loading legend for test-wmts-layer",
+      );
+    });
+
+    it("renders a message when the legend image fails to load", async () => {
+      const el = await createLegendFromLayer(baseWmsLayer);
+      const img = el?.querySelector("img");
+
+      img?.dispatchEvent(new Event("error"));
+
+      expect(el?.querySelector("span")?.textContent).toBe(
         "Legend not available for test-layer",
       );
-    }
-  });
-
-  it("adds accessibility attributes", async () => {
-    const result = await createLegendFromLayer(baseWmsLayer);
-
-    expect(result?.getAttribute("role")).toBe("region");
-    expect(result?.getAttribute("aria-label")).toBe("Map Layer Legend");
+    });
   });
 });

--- a/packages/legend/lib/create-legend/from-layer.test.ts
+++ b/packages/legend/lib/create-legend/from-layer.test.ts
@@ -98,6 +98,12 @@ describe("legend", () => {
       expect(url).toContain("STYLE=my_custom_style");
     });
 
+    it("omits the STYLE parameter when the style is an empty string", async () => {
+      const url = await createLegendUrlFromLayer({ ...baseWmsLayer, style: "" });
+
+      expect(url).not.toContain("STYLE=");
+    });
+
     it("resolves a WMTS legend URL", async () => {
       mockWmtsLayer([{ legendUrl: "https://example.com/legend.png" }]);
 

--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -84,7 +84,7 @@ function createWmsLegendUrl(
   legendUrl.searchParams.set("LAYER", layer.name);
   legendUrl.searchParams.set("LAYERTITLE", false.toString()); // Disable layer title for QGIS Server
   legendUrl.searchParams.set("SLD_VERSION", "1.1.0"); // Default SLD version
-  if (layer.style !== undefined) {
+  if (layer.style) {
     legendUrl.searchParams.set("STYLE", layer.style);
   }
   if (widthPxHint) {
@@ -118,7 +118,7 @@ async function createWmtsLegendUrl(
 
   if (layerByName.styles && layerByName.styles.length > 0) {
     // If a specific style is requested, find its legend URL
-    if (layer.style !== undefined) {
+    if (layer.style) {
       const matchingStyle = layerByName.styles.find(
         (s: { name?: string }) => s.name === layer.style,
       );

--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -7,20 +7,55 @@ import {
 import { WmtsEndpoint } from "@camptocamp/ogc-client";
 
 /**
- * Configuration options for legend generation
+ * Configuration options for legend generation.
  */
-interface LegendOptions {
+export interface LegendOptions {
   format?: string;
   widthPxHint?: number;
   heightPxHint?: number;
 }
 
 /**
- * Create a legend URL for a WMS layer
+ * A single legend entry for a layer.
  *
- * @param layer - The MapContextLayer to create a legend URL for
- * @param options - Optional configuration for legend generation
- * @returns A URL for the WMS legend graphic
+ * Currently an entry is an image graphic (WMS GetLegendGraphic, WMTS legend URL)
+ * that can be rendered directly with an `<img>`.
+ *
+ * Vector layers are not handled yet; they will be supported later, likely by
+ * adding a discriminating `type` field and a `VectorStyle` (from
+ * `@geospatial-sdk/core`) to be rendered client-side as a swatch.
+ */
+export interface LegendEntry {
+  url: string;
+  label: string;
+}
+
+/**
+ * Whether a layer type can carry a legend.
+ *
+ * This is a cheap, type-level check; it does not guarantee that a legend actually
+ * exists (a WMTS layer may declare no legend URL). Use it to gate UI, and use the
+ * result of {@link createLegendUrlFromLayer} to know whether a graphic is available.
+ *
+ * @param layer - The layer to check.
+ * @returns `true` if the layer is a WMS or WMTS layer with a URL and a name.
+ */
+export function hasLegendSupport(
+  layer: MapContextLayer,
+): layer is MapContextLayerWms | MapContextLayerWmts {
+  return (
+    (layer.type === "wms" || layer.type === "wmts") &&
+    !!layer.url &&
+    !!layer.name
+  );
+}
+
+/**
+ * Create a legend URL for a WMS layer.
+ *
+ * @param layer - The MapContextLayer to create a legend URL for.
+ * @param options - Optional configuration for legend generation.
+ * @returns A URL for the WMS legend graphic.
  */
 function createWmsLegendUrl(
   layer: MapContextLayerWms,
@@ -61,10 +96,11 @@ function createWmsLegendUrl(
 }
 
 /**
- * Create a legend URL for a WMTS layer
+ * Create a legend URL for a WMTS layer.
  *
- * @param layer - The MapContextLayer to create a legend URL for
- * @returns A URL for the WMTS legend graphic or null if not available
+ * @param layer - The WMTS layer to create a legend URL for.
+ * @returns A URL for the WMTS legend graphic, or `null` if none is declared.
+ * @throws If the WMTS endpoint cannot be read or the layer is not found.
  */
 async function createWmtsLegendUrl(
   layer: MapContextLayerWmts,
@@ -93,26 +129,86 @@ async function createWmtsLegendUrl(
 }
 
 /**
- * Creates a legend from a layer.
+ * Resolve the legend graphic URL for a raster layer.
  *
- * @param {MapContextLayer} layer - The layer to create the legend from.
- * @param {LegendOptions} [options] - The options to create the legend.
- * @returns {Promise<HTMLElement | null>} A promise that resolves to the legend element or `null` if the legend could not be created.
+ * @param layer - The layer to resolve a legend URL for.
+ * @param options - Optional configuration for legend generation.
+ * @returns The legend URL, or `null` if the layer declares no legend (e.g. a WMTS
+ *   layer whose styles carry no legend URL).
+ * @throws If the layer type does not support legends, if it is missing a url or
+ *   name, or if resolving the URL fails (e.g. the WMTS GetCapabilities request
+ *   fails or the layer is not found).
+ */
+export async function createLegendUrlFromLayer(
+  layer: MapContextLayer,
+  options: LegendOptions = {},
+): Promise<string | null> {
+  if (layer.type !== "wms" && layer.type !== "wmts") {
+    throw new Error(
+      `Cannot create a legend for a layer of type "${layer.type}"`,
+    );
+  }
+  if (!layer.url || !layer.name) {
+    throw new Error(
+      `Cannot create a legend for layer "${layer.name}": missing url or name`,
+    );
+  }
+
+  if (layer.type === "wms") {
+    return createWmsLegendUrl(layer, options).toString();
+  }
+
+  // Only case left is WMTS
+  return createWmtsLegendUrl(layer);
+}
+
+/**
+ * Build the list of legend entries for a layer.
+ *
+ * Today this yields at most one `image` entry for WMS/WMTS layers. It returns an
+ * array so that multi-style raster layers and (future) vector layers — which
+ * produce one entry per style rule — fit without an API change.
+ *
+ * @param layer - The layer to build legend entries for.
+ * @param options - Optional configuration for legend generation.
+ * @returns The legend entries, or an empty array if the layer has no legend.
+ * @throws If the layer type does not support legends, or if resolving fails.
+ */
+export async function createLegendEntriesFromLayer(
+  layer: MapContextLayer,
+  options: LegendOptions = {},
+): Promise<LegendEntry[]> {
+  const url = await createLegendUrlFromLayer(layer, options);
+  if (!url) {
+    return [];
+  }
+
+  // createLegendUrlFromLayer throws unless the layer is a WMS/WMTS layer with a
+  // name, so a non-null url guarantees `layer.name` is present.
+  const { name } = layer as MapContextLayerWms | MapContextLayerWmts;
+  return [{ url, label: name }];
+}
+
+/**
+ * Build a legend DOM element for a layer.
+ *
+ * @deprecated This couples the package to the DOM and to its own CSS classes.
+ *   Prefer {@link createLegendEntriesFromLayer} (or {@link createLegendUrlFromLayer})
+ *   and render the result with your own framework.
+ *
+ * @param layer - The layer to build a legend element for.
+ * @param options - Optional configuration for legend generation.
+ * @returns A legend element, or `null` if the layer does not support legends.
  */
 export async function createLegendFromLayer(
   layer: MapContextLayer,
   options: LegendOptions = {},
 ): Promise<HTMLElement | null> {
-  if (
-    (layer.type !== "wms" && layer.type !== "wmts") ||
-    !layer.url ||
-    !layer.name
-  ) {
+  if (!hasLegendSupport(layer)) {
     console.error("Invalid layer for legend creation");
     return null;
   }
 
-  // Create a container for the legend
   const legendDiv = document.createElement("div");
   legendDiv.id = "legend";
   legendDiv.setAttribute("role", "region");
@@ -131,7 +227,6 @@ export async function createLegendFromLayer(
   img.alt = `Legend for ${layer.name}`;
   img.classList.add("geosdk--legend-layer-image");
 
-  // Error handling for failed image loading
   img.onerror = (e) => {
     console.warn(`Failed to load legend for layer: ${layer.name}`, e);
     const errorMessage = document.createElement("span");
@@ -140,16 +235,7 @@ export async function createLegendFromLayer(
   };
 
   try {
-    let legendUrl: string | null = null;
-
-    // Determine legend URL based on layer type
-    if (layer.type === "wms") {
-      legendUrl = createWmsLegendUrl(layer, options).toString();
-    } else if (layer.type === "wmts") {
-      legendUrl = await createWmtsLegendUrl(layer);
-    }
-
-    // If legend URL is available, set the image source
+    const legendUrl = await createLegendUrlFromLayer(layer, options);
     if (legendUrl) {
       img.src = legendUrl;
       layerDiv.appendChild(img);

--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -108,6 +108,11 @@ async function createWmtsLegendUrl(
   const endpoint = await new WmtsEndpoint(layer.url).isReady();
 
   const layerByName = endpoint.getLayerByName(layer.name);
+  if (!layerByName) {
+    throw new Error(
+      `WMTS layer "${layer.name}" was not found in the endpoint capabilities`,
+    );
+  }
 
   if (layerByName.styles && layerByName.styles.length > 0) {
     // If a specific style is requested, find its legend URL

--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -4,7 +4,7 @@ import {
   MapContextLayerWmts,
   removeSearchParams,
 } from "@geospatial-sdk/core";
-import { WmtsEndpoint } from "@camptocamp/ogc-client";
+import { WmsEndpoint, WmtsEndpoint } from "@camptocamp/ogc-client";
 
 /**
  * Configuration options for legend generation.
@@ -53,13 +53,50 @@ export function hasLegendSupport(
 }
 
 /**
- * Create a legend URL for a WMS layer.
+ * Resolve the legend URL for a WMS layer.
+ *
+ * Prefers the `LegendURL` advertised in the service capabilities (matching the
+ * requested style, else the first style), since many WMS servers do not implement
+ * the `GetLegendGraphic` operation. Falls back to a built `GetLegendGraphic`
+ * request when no legend is advertised or the capabilities cannot be read.
+ *
+ * @param layer - The WMS layer to resolve a legend URL for.
+ * @param options - Optional configuration for legend generation.
+ * @returns The advertised or built WMS legend URL.
+ */
+async function createWmsLegendUrl(
+  layer: MapContextLayerWms,
+  options: LegendOptions = {},
+): Promise<string> {
+  try {
+    const endpoint = await new WmsEndpoint(layer.url).isReady();
+    const layerByName = endpoint.getLayerByName(layer.name);
+    const style =
+      (layer.style
+        ? layerByName?.styles?.find((s) => s.name === layer.style)
+        : undefined) ?? layerByName?.styles?.[0];
+    if (style?.legendUrl) {
+      return style.legendUrl;
+    }
+  } catch (error) {
+    console.warn(
+      `Failed to read WMS capabilities for legend of "${layer.name}"; ` +
+        `falling back to GetLegendGraphic`,
+      error,
+    );
+  }
+
+  return buildWmsGetLegendGraphicUrl(layer, options).toString();
+}
+
+/**
+ * Build a `GetLegendGraphic` request URL for a WMS layer.
  *
  * @param layer - The MapContextLayer to create a legend URL for.
  * @param options - Optional configuration for legend generation.
  * @returns A URL for the WMS legend graphic.
  */
-function createWmsLegendUrl(
+function buildWmsGetLegendGraphicUrl(
   layer: MapContextLayerWms,
   options: LegendOptions = {},
 ): URL {
@@ -162,7 +199,7 @@ export async function createLegendUrlFromLayer(
   }
 
   if (layer.type === "wms") {
-    return createWmsLegendUrl(layer, options).toString();
+    return createWmsLegendUrl(layer, options);
   }
 
   // Only case left is WMTS

--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -18,14 +18,16 @@ export interface LegendOptions {
 /**
  * A single legend entry for a layer.
  *
- * Currently an entry is an image graphic (WMS GetLegendGraphic, WMTS legend URL)
- * that can be rendered directly with an `<img>`.
+ * Currently the only kind is an `"image"` graphic (WMS GetLegendGraphic, WMTS
+ * legend URL) that can be rendered directly with an `<img>`.
  *
- * Vector layers are not handled yet; they will be supported later, likely by
- * adding a discriminating `type` field and a `VectorStyle` (from
- * `@geospatial-sdk/core`) to be rendered client-side as a swatch.
+ * The `type` discriminant is present from the start so vector layers can be
+ * added later (e.g. a `"swatch"` entry carrying a `VectorStyle` from
+ * `@geospatial-sdk/core`, rendered client-side) without a breaking change to
+ * existing consumers.
  */
 export interface LegendEntry {
+  type: "image";
   url: string;
   label: string;
 }
@@ -191,7 +193,7 @@ export async function createLegendEntriesFromLayer(
   // createLegendUrlFromLayer throws unless the layer is a WMS/WMTS layer with a
   // name, so a non-null url guarantees `layer.name` is present.
   const { name } = layer as MapContextLayerWms | MapContextLayerWmts;
-  return [{ url, label: name }];
+  return [{ type: "image", url, label: name }];
 }
 
 /**

--- a/packages/legend/lib/create-legend/index.ts
+++ b/packages/legend/lib/create-legend/index.ts
@@ -3,4 +3,10 @@
  * @packageDocumentation
  */
 
-export { createLegendFromLayer } from "./from-layer.js";
+export {
+  hasLegendSupport,
+  createLegendUrlFromLayer,
+  createLegendEntriesFromLayer,
+  createLegendFromLayer,
+} from "./from-layer.js";
+export type { LegendEntry, LegendOptions } from "./from-layer.js";

--- a/packages/legend/package.json
+++ b/packages/legend/package.json
@@ -29,8 +29,14 @@
     "test": "vitest",
     "build": "tsc"
   },
-  "devDependencies": {
+  "dependencies": {
     "@geospatial-sdk/core": "^0.0.5-alpha.2"
+  },
+  "peerDependencies": {
+    "@camptocamp/ogc-client": "1.3.1-dev.53a6449"
+  },
+  "devDependencies": {
+    "@camptocamp/ogc-client": "1.3.1-dev.53a6449"
   },
   "bugs": {
     "url": "https://github.com/camptocamp/geospatial-sdk/issues"


### PR DESCRIPTION
# refactor(legend): data-first API

Reworks `@geospatial-sdk/legend`: it now returns data (URLs and entries) and leaves rendering to the consumer.

## Changes

- Add `createLegendUrlFromLayer` — resolves the raster legend graphic URL (`null` when none is declared).
- Add `createLegendEntriesFromLayer` — returns `LegendEntry[]`, the list to render however you like.
- Add `hasLegendSupport` — cheap type-level guard for gating UI.
- Add a `type` discriminant to `LegendEntry` so vector swatches can be added later without a breaking change.
- Deprecate `createLegendFromLayer` (the DOM builder coupled the package to the DOM and its own CSS classes).
- Throw a clear error when a WMTS layer is absent from the capabilities.
- Omit the `STYLE` param when the layer style is an empty string.
- Resolve the advertised WMS `LegendURL` from the service capabilities (matching the requested style, else the first style) before falling back to a built `GetLegendGraphic` request — mirroring the WMTS path. Fixes legends on servers that don't implement `GetLegendGraphic` (e.g. `data.geopf.fr`).
- Declare `@geospatial-sdk/core` and `@camptocamp/ogc-client` as proper deps.

## Notes

Legends are supported for **WMS** and **WMTS** layers.
