### PR TITLE
feat: add support for WMS time dimension

### DIFF
--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -11,10 +11,9 @@ export type LayerDimensionValueRange = {
  * @private
  * @inline
  */
-export type LayerDimensionValues = Record<
-  string,
-  LayerDimensionValueSingle | LayerDimensionValueRange
->;
+// TODO: support `LayerDimensionValueRange` values (formatted as `start/end` per
+// the WMS spec) in the map implementations; only single values are handled today.
+export type LayerDimensionValues = Record<string, LayerDimensionValueSingle>;
 
 /**
  * @private
@@ -90,7 +89,6 @@ export interface MapContextLayerWms extends MapContextBaseLayer {
   type: "wms";
   url: string;
   name: string;
-  // TODO: add support for these
   dimensionValues?: LayerDimensionValues;
   style?: string;
 

--- a/packages/core/lib/utils/hash.test.ts
+++ b/packages/core/lib/utils/hash.test.ts
@@ -23,6 +23,21 @@ describe("getHash", () => {
     ]);
     expect(hashB).toEqual(hashA);
   });
+  it("stable for identical Date values", () => {
+    const hashA = getHash(new Date("2020-01-01T00:00:00.000Z"));
+    const hashB = getHash(new Date("2020-01-01T00:00:00.000Z"));
+    expect(hashB).toEqual(hashA);
+  });
+  it("different for different Date values", () => {
+    const hashA = getHash(new Date("2020-01-01T00:00:00.000Z"));
+    const hashB = getHash(new Date("2021-06-15T12:30:00.000Z"));
+    expect(hashB).not.toEqual(hashA);
+  });
+  it("different when a nested Date value changes", () => {
+    const hashA = getHash({ time: new Date("2020-01-01T00:00:00.000Z") });
+    const hashB = getHash({ time: new Date("2021-06-15T12:30:00.000Z") });
+    expect(hashB).not.toEqual(hashA);
+  });
   it("stable for null", () => {
     const hashA = getHash(null);
     const hashB = getHash(null);

--- a/packages/core/lib/utils/hash.ts
+++ b/packages/core/lib/utils/hash.ts
@@ -3,6 +3,9 @@ function isGeoJsonGeometry(object: object) {
 }
 
 export function getHash(input: unknown, ignoreKeys: string[] = []): string {
+  if (input instanceof Date) {
+    return input.toISOString();
+  }
   if (input instanceof Object && isGeoJsonGeometry(input)) {
     return JSON.stringify(input); // do not compute an actual hash as it will take too long
   } else if (input instanceof Object) {

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -216,6 +216,25 @@ describe("MapContextService", () => {
           TILED: true,
         });
       });
+      it("sets WMS dimension params with uppercased keys and ISO Date values", async () => {
+        layerModel = {
+          ...MAP_CTX_LAYER_WMS_FIXTURE,
+          dimensionValues: {
+            time: new Date("2020-01-01T00:00:00.000Z"),
+            elevation: 500,
+          },
+        };
+        layer = await createLayer(layerModel);
+        const source = layer.getSource() as TileWMS;
+        const params = source.getParams();
+        expect(params).toEqual({
+          LAYERS: (layerModel as MapContextLayerWms).name,
+          STYLES: (layerModel as MapContextLayerWms).style,
+          TILED: true,
+          TIME: "2020-01-01T00:00:00.000Z",
+          ELEVATION: 500,
+        });
+      });
       it("set correct url without existing REQUEST and SERVICE params", () => {
         const source = layer.getSource() as TileWMS;
         const urls = source.getUrls() || [];
@@ -303,6 +322,25 @@ describe("MapContextService", () => {
             LAYERS: (layerModel as MapContextLayerWms).name,
             FORMAT: "image/jpeg",
             STYLES: (layerModel as MapContextLayerWms).style,
+          });
+        });
+        it("sets WMS dimension params with uppercased keys and ISO Date values", async () => {
+          layerModel = {
+            ...MAP_CTX_LAYER_WMS_FIXTURE,
+            useTiles: false,
+            dimensionValues: {
+              time: new Date("2020-01-01T00:00:00.000Z"),
+              elevation: 500,
+            },
+          };
+          layer = await createLayer(layerModel);
+          const source = layer.getSource() as ImageWMS;
+          const params = source.getParams();
+          expect(params).toEqual({
+            LAYERS: (layerModel as MapContextLayerWms).name,
+            STYLES: (layerModel as MapContextLayerWms).style,
+            TIME: "2020-01-01T00:00:00.000Z",
+            ELEVATION: 500,
           });
         });
         it("set correct url without existing REQUEST and SERVICE params", () => {

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -50,6 +50,7 @@ import {
   propagateLayerStateChangeEventToMap,
 } from "./register-events.js";
 import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
+import { buildWmsParams } from "./wms-params.js";
 import ImageLayer from "ol/layer/Image.js";
 import ImageWMS from "ol/source/ImageWMS.js";
 
@@ -103,11 +104,7 @@ export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
     case "wms":
       {
         const url = removeSearchParams(layerModel.url, ["request", "service"]);
-        const params = {
-          LAYERS: layerModel.name,
-          ...(layerModel.format && { FORMAT: layerModel.format }),
-          ...(layerModel.style && { STYLES: layerModel.style }),
-        };
+        const params = buildWmsParams(layerModel);
         if (layerModel.useTiles === false) {
           layer = new ImageLayer({
             source: new ImageWMS({

--- a/packages/openlayers/lib/map/layer-update.test.ts
+++ b/packages/openlayers/lib/map/layer-update.test.ts
@@ -2,15 +2,15 @@ import {
   canDoIncrementalUpdate,
   updateLayerProperties,
 } from "./layer-update.js";
-import { MapContextLayer } from "@geospatial-sdk/core";
+import { MapContextLayer, MapContextLayerWms } from "@geospatial-sdk/core";
 import Layer from "ol/layer/Layer.js";
-import { Source } from "ol/source.js";
 import {
   SAMPLE_LAYER1,
   SAMPLE_LAYER3,
 } from "@geospatial-sdk/core/fixtures/map-context.fixtures.js";
-import VectorSource from "ol/source/Vector.js";
 import VectorLayer from "ol/layer/Vector.js";
+import TileLayer from "ol/layer/Tile.js";
+import TileWMS from "ol/source/TileWMS.js";
 
 describe("Layer update utils", () => {
   describe("canDoIncrementalUpdate", () => {
@@ -52,14 +52,30 @@ describe("Layer update utils", () => {
       } as MapContextLayer;
       expect(canDoIncrementalUpdate(oldLayer, newLayer)).toBe(false);
     });
+    it("returns true when only WMS dimension values change", () => {
+      const oldLayer = {
+        name: "layer1",
+        type: "wms",
+        url: "https://example.com/wms",
+        dimensionValues: { time: new Date("2020-01-01T00:00:00.000Z") },
+      } as MapContextLayer;
+      const newLayer = {
+        name: "layer1",
+        type: "wms",
+        url: "https://example.com/wms",
+        dimensionValues: { time: new Date("2021-06-15T12:30:00.000Z") },
+      } as MapContextLayer;
+      expect(canDoIncrementalUpdate(oldLayer, newLayer)).toBe(true);
+    });
   });
 
   describe("updateLayerProperties", () => {
     let olLayer: Layer;
-    let olSource: Source;
+    let olSource: TileWMS;
 
     beforeEach(() => {
-      olSource = new VectorSource({});
+      // SAMPLE_LAYER1 is a WMS model, so its source must be a WMS source
+      olSource = new TileWMS({ url: "http://abc.org/wms", params: {} });
       olLayer = new Layer({ source: olSource });
       vi.spyOn(olLayer, "setVisible");
       vi.spyOn(olLayer, "setOpacity");
@@ -141,6 +157,75 @@ describe("Layer update utils", () => {
         "--geospatial-sdk-clickable",
         false,
       );
+    });
+  });
+
+  describe("updateLayerProperties (WMS source params)", () => {
+    let olLayer: Layer;
+    let olSource: TileWMS;
+
+    const baseModel = {
+      type: "wms",
+      url: "https://example.com/wms",
+      name: "myLayer",
+    } as MapContextLayerWms;
+
+    beforeEach(() => {
+      olSource = new TileWMS({
+        url: "https://example.com/wms",
+        params: { LAYERS: "myLayer", TILED: true },
+      });
+      olLayer = new TileLayer({ source: olSource });
+      vi.spyOn(olSource, "updateParams");
+    });
+
+    it("applies changed dimension values to the source with uppercased keys and ISO dates", () => {
+      const prev = {
+        ...baseModel,
+        dimensionValues: { time: new Date("2020-01-01T00:00:00.000Z") },
+      };
+      const next = {
+        ...baseModel,
+        dimensionValues: {
+          time: new Date("2021-06-15T12:30:00.000Z"),
+          elevation: 500,
+        },
+      };
+      updateLayerProperties(next, olLayer, prev);
+      expect(olSource.updateParams).toHaveBeenCalledWith({
+        LAYERS: "myLayer",
+        TIME: "2021-06-15T12:30:00.000Z",
+        ELEVATION: 500,
+      });
+    });
+
+    it("resets dimension params that no longer exist to undefined", () => {
+      const prev = {
+        ...baseModel,
+        dimensionValues: {
+          time: new Date("2020-01-01T00:00:00.000Z"),
+          elevation: 500,
+        },
+      };
+      const next = {
+        ...baseModel,
+        dimensionValues: { time: new Date("2020-01-01T00:00:00.000Z") },
+      };
+      updateLayerProperties(next, olLayer, prev);
+      expect(olSource.updateParams).toHaveBeenCalledWith({
+        LAYERS: "myLayer",
+        TIME: "2020-01-01T00:00:00.000Z",
+        ELEVATION: undefined,
+      });
+    });
+
+    it("does not touch the source on creation (no previous model)", () => {
+      const next = {
+        ...baseModel,
+        dimensionValues: { time: new Date("2020-01-01T00:00:00.000Z") },
+      };
+      updateLayerProperties(next, olLayer);
+      expect(olSource.updateParams).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/openlayers/lib/map/layer-update.ts
+++ b/packages/openlayers/lib/map/layer-update.ts
@@ -3,15 +3,20 @@ import {
   MapContextBaseLayer,
   MapContextLayer,
   MapContextLayerVector,
+  MapContextLayerWms,
 } from "@geospatial-sdk/core";
 import Layer from "ol/layer/Layer.js";
 import VectorLayer from "ol/layer/Vector.js";
 import type VectorSource from "ol/source/Vector.js";
+import type TileWMS from "ol/source/TileWMS.js";
+import type ImageWMS from "ol/source/ImageWMS.js";
 import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
+import { buildWmsParams } from "./wms-params.js";
 
 const UPDATABLE_PROPERTIES: (
   | keyof MapContextBaseLayer
   | keyof MapContextLayerVector
+  | keyof MapContextLayerWms
 )[] = [
   "opacity",
   "visibility",
@@ -23,6 +28,7 @@ const UPDATABLE_PROPERTIES: (
   "clickable",
   "style",
   "hoverStyle",
+  "dimensionValues",
   // TODO (when available) "zIndex"
 ];
 
@@ -103,5 +109,44 @@ export function updateLayerProperties(
       (layerModel as MapContextLayerVector).style,
     );
   }
+  // only relevant on update: on creation the source is built with the correct
+  // params already, so there is nothing to re-apply
+  if (previousLayerModel && layerModel.type === "wms") {
+    updateWmsSourceParams(
+      layerModel,
+      olLayer,
+      previousLayerModel as MapContextLayerWms,
+    );
+  }
   // TODO: z-index
+}
+
+/**
+ * Applies WMS request params (LAYERS, STYLES, FORMAT, dimension values) to the
+ * layer's source via `updateParams`, which triggers a single re-render instead
+ * of recreating the layer.
+ *
+ * `updateParams` merges, so params present in the previous model but absent from
+ * the new one are explicitly reset to `undefined` (OpenLayers omits undefined
+ * params from the request URL).
+ */
+function updateWmsSourceParams(
+  layerModel: MapContextLayerWms,
+  olLayer: Layer,
+  previousLayerModel: MapContextLayerWms,
+) {
+  const source = olLayer.getSource() as TileWMS | ImageWMS | null;
+  if (!source) return;
+
+  const params = buildWmsParams(layerModel);
+
+  // reset params that existed before but no longer do, so stale dimensions
+  // (e.g. a removed TIME) don't linger after the merge performed by updateParams
+  for (const key of Object.keys(buildWmsParams(previousLayerModel))) {
+    if (!(key in params)) {
+      params[key] = undefined;
+    }
+  }
+
+  source.updateParams(params);
 }

--- a/packages/openlayers/lib/map/layer-update.ts
+++ b/packages/openlayers/lib/map/layer-update.ts
@@ -139,10 +139,14 @@ function updateWmsSourceParams(
   if (!source) return;
 
   const params = buildWmsParams(layerModel);
+  const previousParams = buildWmsParams(previousLayerModel);
+
+  // nothing WMS-relevant changed: skip updateParams to avoid a needless re-render
+  if (getHash(params) === getHash(previousParams)) return;
 
   // reset params that existed before but no longer do, so stale dimensions
   // (e.g. a removed TIME) don't linger after the merge performed by updateParams
-  for (const key of Object.keys(buildWmsParams(previousLayerModel))) {
+  for (const key of Object.keys(previousParams)) {
     if (!(key in params)) {
       params[key] = undefined;
     }

--- a/packages/openlayers/lib/map/wms-params.ts
+++ b/packages/openlayers/lib/map/wms-params.ts
@@ -1,0 +1,25 @@
+import { MapContextLayerWms } from "@geospatial-sdk/core";
+
+/**
+ * Builds the WMS request params (excluding transport-specific ones like `TILED`)
+ * from a layer model. Dimension keys are uppercased per the WMS convention and
+ * `Date` values are serialized to ISO strings.
+ *
+ * Shared between layer creation and incremental updates so both stay in sync.
+ */
+export function buildWmsParams(
+  layerModel: MapContextLayerWms,
+): Record<string, unknown> {
+  return {
+    LAYERS: layerModel.name,
+    ...(layerModel.format && { FORMAT: layerModel.format }),
+    ...(layerModel.style && { STYLES: layerModel.style }),
+    ...(layerModel.dimensionValues &&
+      Object.fromEntries(
+        Object.entries(layerModel.dimensionValues).map(([k, v]) => [
+          k.toUpperCase(),
+          v instanceof Date ? v.toISOString() : v,
+        ]),
+      )),
+  };
+}


### PR DESCRIPTION
Adds support for WMS dimension values (TIME, ELEVATION, custom dims) on WMS layers, applied both at layer creation and via incremental update.

### Changes

  - buildWmsParams (new) — builds WMS request params from a layer model, uppercasing dimension keys and serializing Date values to ISO strings. Shared between layer creation and updates so both stay in sync.
  - Incremental updates — dimensionValues is now an updatable property; changes apply via source.updateParams() (single re-render, no layer recreation). Dimensions removed between models are reset to undefined so stale values don't linger through the merge.
  - getHash — handles Date values, so canDoIncrementalUpdate detects dimension changes instead of treating Dates as identical.
  - Type narrowing — LayerDimensionValues restricted to single values for now; LayerDimensionValueRange (start/end per WMS spec) is left as a TODO.

