### PR TITLE
feat: sync map with context helper

### DIFF
--- a/packages/elements/lib/map-element.ts
+++ b/packages/elements/lib/map-element.ts
@@ -1,11 +1,8 @@
 import { css, html, LitElement, PropertyValues } from "lit";
 import { customElement, property, query } from "lit/decorators.js";
-import { computeMapContextDiff, MapContext } from "@geospatial-sdk/core";
+import { MapContext } from "@geospatial-sdk/core";
 import OlMap from "ol/Map.js";
-import {
-  applyContextDiffToMap,
-  createMapFromContext,
-} from "@geospatial-sdk/openlayers";
+import { syncMapWithContext, MapSyncHandle } from "@geospatial-sdk/openlayers";
 
 @customElement("geosdk-map")
 export class SdkMapElement extends LitElement {
@@ -25,25 +22,42 @@ export class SdkMapElement extends LitElement {
   @query("div")
   accessor mapElement!: HTMLDivElement;
 
-  private map: OlMap | null = null;
+  private sync: MapSyncHandle | null = null;
+  private onContextChange: (() => void) | null = null;
 
   public async firstUpdated() {
-    this.map = await createMapFromContext(this.context, this.mapElement);
+    await this.startSync();
   }
 
-  public async updated(changedProperties: PropertyValues<this>) {
+  // Re-attaching the element to the DOM rebuilds the map; disconnect tears it
+  // down. firstUpdated handles the very first connect (mapElement isn't
+  // rendered yet at the initial connectedCallback).
+  public connectedCallback() {
+    super.connectedCallback();
+    if (this.hasUpdated && !this.sync) void this.startSync();
+  }
+
+  private async startSync() {
+    this.sync = await syncMapWithContext(
+      this.mapElement,
+      () => this.context,
+      (onChange) => {
+        this.onContextChange = onChange;
+        return () => (this.onContextChange = null);
+      },
+    );
+  }
+
+  public updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("context")) {
-      await this.contextHasChanged(
-        changedProperties.get("context"),
-        this.context,
-      );
+      this.onContextChange?.();
     }
   }
 
-  async contextHasChanged(value: MapContext | undefined, oldValue: MapContext) {
-    if (!this.map || !value) return;
-    const diff = computeMapContextDiff(value, oldValue);
-    await applyContextDiffToMap(this.map, diff);
+  public disconnectedCallback() {
+    super.disconnectedCallback();
+    this.sync?.stop();
+    this.sync = null;
   }
 
   render() {
@@ -55,7 +69,7 @@ export class SdkMapElement extends LitElement {
     return this;
   }
 
-  public get olMap() {
-    return this.map;
+  public get olMap(): OlMap | null {
+    return this.sync?.map ?? null;
   }
 }

--- a/packages/openlayers/lib/map/index.ts
+++ b/packages/openlayers/lib/map/index.ts
@@ -5,5 +5,6 @@
 
 export { createMapFromContext, resetMapFromContext } from "./create-map.js";
 export { applyContextDiffToMap } from "./apply-context-diff.js";
+export { syncMapWithContext, type MapSyncHandle } from "./sync-map.js";
 export { listen } from "./listen.js";
 export { readMapViewState } from "./resolved-map-state.js";

--- a/packages/openlayers/lib/map/sync-map.test.ts
+++ b/packages/openlayers/lib/map/sync-map.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { MapContext } from "@geospatial-sdk/core";
+import Map from "ol/Map.js";
+
+let resolveCreate: (map: Map) => void;
+const createMapFromContext = vi.fn();
+const applyContextDiffToMap = vi.fn();
+
+vi.mock("./create-map.js", () => ({
+  createMapFromContext: (...args: unknown[]) => createMapFromContext(...args),
+}));
+vi.mock("./apply-context-diff.js", () => ({
+  applyContextDiffToMap: (...args: unknown[]) => applyContextDiffToMap(...args),
+}));
+// Mock the diff so applyContextDiffToMap receives the target zoom directly,
+// letting tests assert on apply order without depending on the diff's shape.
+vi.mock("@geospatial-sdk/core", () => ({
+  computeMapContextDiff: (next: MapContext) => ({
+    zoom: (next.view as { zoom?: number }).zoom,
+  }),
+}));
+
+const { syncMapWithContext } = await import("./sync-map.js");
+
+function ctx(zoom: number): MapContext {
+  return { view: { center: [0, 0], zoom }, layers: [] };
+}
+
+const fakeMap = {} as Map;
+
+beforeEach(() => {
+  createMapFromContext.mockReset();
+  applyContextDiffToMap.mockReset();
+  applyContextDiffToMap.mockResolvedValue(fakeMap);
+  createMapFromContext.mockImplementation(
+    () => new Promise<Map>((r) => (resolveCreate = r)),
+  );
+});
+
+afterEach(() => vi.restoreAllMocks());
+
+describe("syncMapWithContext", () => {
+  it("applies the catch-up diff for a change that lands during creation", async () => {
+    let current = ctx(2);
+    const noopSubscribe = () => () => {};
+
+    const promise = syncMapWithContext("t", () => current, noopSubscribe);
+    // Context changes while createMapFromContext is still pending.
+    current = ctx(5);
+    resolveCreate(fakeMap);
+    const handle = await promise;
+
+    expect(handle.map).toBe(fakeMap);
+    // The ctx(5) that landed during creation is caught up once the map is ready.
+    expect(applyContextDiffToMap).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not apply a catch-up when context is unchanged during creation", async () => {
+    const current = ctx(2);
+    const promise = syncMapWithContext(
+      "t",
+      () => current,
+      () => () => {},
+    );
+    resolveCreate(fakeMap);
+    await promise;
+    expect(applyContextDiffToMap).not.toHaveBeenCalled();
+  });
+
+  it("serializes applies and preserves order on rapid changes", async () => {
+    let current = ctx(2);
+    let fire: () => void = () => {};
+    const subscribe = (onChange: () => void) => {
+      fire = onChange;
+      return () => {};
+    };
+
+    const order: number[] = [];
+    applyContextDiffToMap.mockImplementation((_m, diff) => {
+      // diff carries the target context's zoom via the view change
+      return Promise.resolve().then(() => {
+        order.push((diff as { zoom?: number }).zoom ?? -1);
+        return fakeMap;
+      });
+    });
+
+    const promise = syncMapWithContext("t", () => current, subscribe);
+    resolveCreate(fakeMap);
+    await promise;
+
+    // Two changes back-to-back before the chain drains.
+    current = ctx(3);
+    fire();
+    current = ctx(4);
+    fire();
+
+    // let the chain settle
+    await new Promise((r) => setTimeout(r));
+    expect(applyContextDiffToMap).toHaveBeenCalledTimes(2);
+    expect(order).toEqual([3, 4]);
+  });
+
+  it("stop() prevents further applies", async () => {
+    let current = ctx(2);
+    let fire: () => void = () => {};
+    let unsubscribed = false;
+    const subscribe = (onChange: () => void) => {
+      fire = onChange;
+      return () => (unsubscribed = true);
+    };
+
+    const promise = syncMapWithContext("t", () => current, subscribe);
+    resolveCreate(fakeMap);
+    const handle = await promise;
+
+    handle.stop();
+    current = ctx(9);
+    fire();
+    await new Promise((r) => setTimeout(r));
+
+    expect(unsubscribed).toBe(true);
+    expect(applyContextDiffToMap).not.toHaveBeenCalled();
+  });
+});

--- a/packages/openlayers/lib/map/sync-map.ts
+++ b/packages/openlayers/lib/map/sync-map.ts
@@ -1,0 +1,73 @@
+import { computeMapContextDiff, MapContext } from "@geospatial-sdk/core";
+import Map from "ol/Map.js";
+import { createMapFromContext } from "./create-map.js";
+import { applyContextDiffToMap } from "./apply-context-diff.js";
+
+export interface MapSyncHandle {
+  /** The OpenLayers map created from the initial context. */
+  map: Map;
+  /** Unsubscribe from the context source and stop applying further diffs. */
+  stop: () => void;
+}
+
+/**
+ * Create a map from a context source and keep it in sync as the context changes.
+ *
+ * Framework-agnostic: the caller supplies `getContext` (reads the current
+ * context) and `subscribe` (registers a change callback, returns an unsubscribe
+ * function). A Vue caller passes a `watch`; a Lit caller re-renders, etc.
+ *
+ * This handles three races that a naive `create then watch(applyDiff)` misses:
+ *
+ * 1. The context can change while `createMapFromContext` is still awaited. The
+ *    map would otherwise be built from a stale context and the missed change
+ *    silently dropped, so we diff against the current context once the map is
+ *    ready and apply the catch-up.
+ * 2. The previous context must be the one actually *applied*, not the value a
+ *    framework captured at subscribe time (which goes stale across the await).
+ *    We track `lastApplied` ourselves.
+ * 3. `applyContextDiffToMap` is async; rapid changes would otherwise interleave
+ *    on the same map. Applies are serialized through a promise chain.
+ */
+export async function syncMapWithContext(
+  target: string | HTMLElement,
+  getContext: () => MapContext,
+  subscribe: (onChange: () => void) => () => void,
+): Promise<MapSyncHandle> {
+  const initialContext = getContext();
+  const map = await createMapFromContext(initialContext, target);
+
+  let lastApplied = initialContext;
+  let chain: Promise<unknown> = Promise.resolve();
+  let stopped = false;
+
+  function enqueueApply(next: MapContext) {
+    const previous = lastApplied;
+    lastApplied = next;
+    chain = chain.then(() => {
+      if (stopped) return;
+      const diff = computeMapContextDiff(next, previous);
+      return applyContextDiffToMap(map, diff);
+    });
+    return chain;
+  }
+
+  // Catch up on any change that landed while the map was being created.
+  const currentContext = getContext();
+  if (currentContext !== initialContext) {
+    enqueueApply(currentContext);
+  }
+
+  const unsubscribe = subscribe(() => {
+    if (stopped) return;
+    enqueueApply(getContext());
+  });
+
+  return {
+    map,
+    stop: () => {
+      stopped = true;
+      unsubscribe();
+    },
+  };
+}


### PR DESCRIPTION
Extracts the create-map-then-sync logic out of `SdkMapElement` (and https://github.com/camptocamp/sextant-viewer/pull/32 , as smartly advised by @arnaud-morvan) into a framework-agnostic `syncMapWithContext` helper in `@geospatial-sdk/openlayers`.

Fixes three races in the old inline `create then watch(applyDiff)` approach, all caused by `createMapFromContext` being async:

  1. **Lost update** — context changing during creation was dropped.
  2. **Stale previous** — diffs computed against the wrong "previous" context.
  3. **Interleaved applies** — rapid changes raced on the same map.

The helper catches up on changes landing during creation, tracks `lastApplied` itself, and serializes applies through a promise chain. Any renderer caller (Lit now, Vue next) can reuse it.

### Changes

  - `sync-map.ts` (new) — `syncMapWithContext(target, getContext, subscribe)` → `{ map, stop }`.
  - `map-element.ts` — rewired to use it; added connect/disconnect so a re-attached element rebuilds instead of staying dead.
  - `sync-map.test.ts` (new) — catch-up, no-op, apply ordering, `stop()`.

