### PR TITLE
feat: add customParams to MapContextLayerWms for vendor WMS extensions

### DIFF
--- a/docs/guides/map-context.md
+++ b/docs/guides/map-context.md
@@ -73,7 +73,7 @@ WMS layers accept an optional `customParams` property (`Record<string, string>`)
 }
 ```
 
-This is the intended mechanism for NcWMS-specific parameters (Thredds, ERDDAP, CMEMS). Note that `customParams` keys take precedence over SDK-derived params if there is a conflict.
+Use this for any vendor-specific parameters not covered by the OGC standard — NcWMS-based servers (Thredds, ERDDAP, CMEMS) are a common example. Note that `customParams` keys take precedence over SDK-derived params if there is a conflict.
 
 ### Extras
 

--- a/docs/guides/map-context.md
+++ b/docs/guides/map-context.md
@@ -20,8 +20,8 @@ interface MapContext {
 Each layer has a `type` property that determines its data source:
 
 - **`xyz`**: Tiles (raster or vector) aligned on the global Web Mercator grid (EPSG:3857) (`url`)
-- **`wms`**: OGC Web Map Service (`url`, `name`, optional `dimensions`, `style`, `customParams`)
-- **`wmts`**: OGC Web Map Tile Service (`url`, `name`, optional `dimensions`, `style`)
+- **`wms`**: OGC Web Map Service (`url`, `name`, optional `dimensionValues`, `style`, `customParams`)
+- **`wmts`**: OGC Web Map Tile Service (`url`, `name`, optional `dimensionValues`, `style`)
 - **`wfs`**: OGC Web Feature Service (`url`, `featureType`, optional `style`)
 - **`geojson`**: Vector data in GeoJSON format (`url` or `data`, optional `style`)
 - **`ogcapi`**: OGC API, supports Features and Tiles (both raster and vector) (`url`, `collection`, optional `useTiles`, `tileMatrixSet`, `style`)

--- a/docs/guides/map-context.md
+++ b/docs/guides/map-context.md
@@ -20,7 +20,7 @@ interface MapContext {
 Each layer has a `type` property that determines its data source:
 
 - **`xyz`**: Tiles (raster or vector) aligned on the global Web Mercator grid (EPSG:3857) (`url`)
-- **`wms`**: OGC Web Map Service (`url`, `name`, optional `dimensions`, `style`)
+- **`wms`**: OGC Web Map Service (`url`, `name`, optional `dimensions`, `style`, `customParams`)
 - **`wmts`**: OGC Web Map Tile Service (`url`, `name`, optional `dimensions`, `style`)
 - **`wfs`**: OGC Web Feature Service (`url`, `featureType`, optional `style`)
 - **`geojson`**: Vector data in GeoJSON format (`url` or `data`, optional `style`)
@@ -56,6 +56,24 @@ What this means is that _using an `id` for layers is optional, and changes the w
 The vector layers take a `style` property for their symbology. They use the so-called [_OpenLayers flat style format_ (see API doc)](https://openlayers.org/en/latest/apidoc/module-ol_style_flat.html).
 
 This property is optional; if not provided, a default style will be used (depending on the library).
+
+### WMS vendor parameters
+
+WMS layers accept an optional `customParams` property (`Record<string, string>`) for non-standard server extensions. These key-value pairs are appended as-is to every GetMap request:
+
+```typescript
+{
+  type: "wms",
+  url: "https://my.thredds.server/thredds/wms",
+  name: "temperature",
+  customParams: {
+    COLORSCALERANGE: "-2,35",
+    LOGSCALE: "false",
+  },
+}
+```
+
+This is the intended mechanism for NcWMS-specific parameters (Thredds, ERDDAP, CMEMS). Note that `customParams` keys take precedence over SDK-derived params if there is a conflict.
 
 ### Extras
 

--- a/packages/core/lib/model/map-context.ts
+++ b/packages/core/lib/model/map-context.ts
@@ -93,6 +93,13 @@ export interface MapContextLayerWms extends MapContextBaseLayer {
   style?: string;
 
   /**
+   * Vendor-specific WMS parameters that are appended as-is to every GetMap request.
+   * Use this for non-standard server extensions such as NcWMS (`COLORSCALERANGE`, `LOGSCALE`).
+   * Keys are case-sensitive; they are passed without transformation.
+   */
+  customParams?: Record<string, string>;
+
+  /**
    * Whether to use tiled WMS requests. Tiled requests include a `TILED=true` parameter as per https://wiki.osgeo.org/wiki/WMS_Tiling_Client_Recommendation
    *
    * Using tiled requests allow tiles to be cached and thus the server load to potentially be reduced; on the other hand,

--- a/packages/openlayers/lib/map/layer-update.test.ts
+++ b/packages/openlayers/lib/map/layer-update.test.ts
@@ -147,6 +147,25 @@ describe("Layer update utils", () => {
       expect(olLayer.set).toHaveBeenCalledWith("label", "Test Layer");
     });
 
+    it("updates WMS style via source updateParams", () => {
+      const wmsSource = new TileWMS({
+        url: "https://example.com/wms",
+        params: { LAYERS: "myLayer", STYLES: "default" },
+      });
+      const wmsLayer = new TileLayer({ source: wmsSource });
+      vi.spyOn(wmsSource, "updateParams");
+
+      const layerModel = {
+        ...SAMPLE_LAYER1,
+        style: "newStyle",
+      } as MapContextLayer;
+      const prevLayerModel = { ...SAMPLE_LAYER1 } as MapContextLayer;
+      updateLayerProperties(layerModel, wmsLayer, prevLayerModel);
+      expect(wmsSource.updateParams).toHaveBeenCalledWith({
+        STYLES: "newStyle",
+      });
+    });
+
     it("enable interaction-related props without recreating them", async () => {
       // mocking a vector layer
       (olLayer as VectorLayer).setStyle = vi.fn();

--- a/packages/openlayers/lib/map/layer-update.test.ts
+++ b/packages/openlayers/lib/map/layer-update.test.ts
@@ -67,6 +67,21 @@ describe("Layer update utils", () => {
       } as MapContextLayer;
       expect(canDoIncrementalUpdate(oldLayer, newLayer)).toBe(true);
     });
+    it("returns true when only customParams change", () => {
+      const oldLayer = {
+        name: "layer1",
+        type: "wms",
+        url: "https://example.com/wms",
+        customParams: { COLORSCALERANGE: "-2,35" },
+      } as MapContextLayer;
+      const newLayer = {
+        name: "layer1",
+        type: "wms",
+        url: "https://example.com/wms",
+        customParams: { COLORSCALERANGE: "0,100", LOGSCALE: "true" },
+      } as MapContextLayer;
+      expect(canDoIncrementalUpdate(oldLayer, newLayer)).toBe(true);
+    });
   });
 
   describe("updateLayerProperties", () => {
@@ -226,6 +241,39 @@ describe("Layer update utils", () => {
       };
       updateLayerProperties(next, olLayer);
       expect(olSource.updateParams).not.toHaveBeenCalled();
+    });
+
+    it("applies changed customParams to the source via updateParams", () => {
+      const prev = {
+        ...baseModel,
+        customParams: { COLORSCALERANGE: "-2,35" },
+      };
+      const next = {
+        ...baseModel,
+        customParams: { COLORSCALERANGE: "0,100", LOGSCALE: "true" },
+      };
+      updateLayerProperties(next, olLayer, prev);
+      expect(olSource.updateParams).toHaveBeenCalledWith(
+        expect.objectContaining({ COLORSCALERANGE: "0,100", LOGSCALE: "true" }),
+      );
+    });
+
+    it("resets customParams that were removed to undefined", () => {
+      const prev = {
+        ...baseModel,
+        customParams: { COLORSCALERANGE: "-2,35", LOGSCALE: "false" },
+      };
+      const next = {
+        ...baseModel,
+        customParams: { COLORSCALERANGE: "0,100" },
+      };
+      updateLayerProperties(next, olLayer, prev);
+      expect(olSource.updateParams).toHaveBeenCalledWith(
+        expect.objectContaining({
+          COLORSCALERANGE: "0,100",
+          LOGSCALE: undefined,
+        }),
+      );
     });
   });
 });

--- a/packages/openlayers/lib/map/layer-update.ts
+++ b/packages/openlayers/lib/map/layer-update.ts
@@ -102,13 +102,19 @@ export function updateLayerProperties(
   if (shouldApplyProperty("clickable" as keyof MapContextLayer)) {
     olLayer.set(`${GEOSPATIAL_SDK_PREFIX}clickable`, layerModel.clickable);
   }
-  if (
-    shouldApplyProperty("style" as keyof MapContextLayer) &&
-    "setStyle" in olLayer
-  ) {
-    (olLayer as VectorLayer<VectorSource>).setStyle(
-      (layerModel as MapContextLayerVector).style,
-    );
+  if (shouldApplyProperty("style" as keyof MapContextLayer)) {
+    if (layerModel.type === "wms") {
+      const source = olLayer.getSource();
+      if (source && "updateParams" in source) {
+        (source as TileWMS | ImageWMS).updateParams({
+          STYLES: (layerModel as MapContextLayerWms).style,
+        });
+      }
+    } else if ("setStyle" in olLayer) {
+      (olLayer as VectorLayer<VectorSource>).setStyle(
+        (layerModel as MapContextLayerVector).style,
+      );
+    }
   }
   // only relevant on update: on creation the source is built with the correct
   // params already, so there is nothing to re-apply

--- a/packages/openlayers/lib/map/layer-update.ts
+++ b/packages/openlayers/lib/map/layer-update.ts
@@ -29,6 +29,7 @@ const UPDATABLE_PROPERTIES: (
   "style",
   "hoverStyle",
   "dimensionValues",
+  "customParams",
   // TODO (when available) "zIndex"
 ];
 

--- a/packages/openlayers/lib/map/wms-params.test.ts
+++ b/packages/openlayers/lib/map/wms-params.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from "vitest";
+import { buildWmsParams } from "./wms-params.js";
+import { MapContextLayerWms } from "@geospatial-sdk/core";
+
+const BASE_LAYER: MapContextLayerWms = {
+  type: "wms",
+  url: "https://example.com/wms",
+  name: "temperature",
+};
+
+describe("buildWmsParams", () => {
+  it("includes LAYERS from layer name", () => {
+    expect(buildWmsParams(BASE_LAYER)).toMatchObject({ LAYERS: "temperature" });
+  });
+
+  it("includes FORMAT when set", () => {
+    expect(
+      buildWmsParams({ ...BASE_LAYER, format: "image/png" }),
+    ).toMatchObject({ FORMAT: "image/png" });
+  });
+
+  it("omits FORMAT when not set", () => {
+    expect(buildWmsParams(BASE_LAYER)).not.toHaveProperty("FORMAT");
+  });
+
+  it("includes STYLES when set", () => {
+    expect(
+      buildWmsParams({ ...BASE_LAYER, style: "boxfill/rainbow" }),
+    ).toMatchObject({ STYLES: "boxfill/rainbow" });
+  });
+
+  it("omits STYLES when not set", () => {
+    expect(buildWmsParams(BASE_LAYER)).not.toHaveProperty("STYLES");
+  });
+
+  describe("dimensionValues", () => {
+    it("uppercases dimension keys", () => {
+      expect(
+        buildWmsParams({
+          ...BASE_LAYER,
+          dimensionValues: { time: "2023-01-01", elevation: "-10" },
+        }),
+      ).toMatchObject({ TIME: "2023-01-01", ELEVATION: "-10" });
+    });
+
+    it("serializes Date values to ISO strings", () => {
+      const date = new Date("2023-06-15T12:00:00Z");
+      expect(
+        buildWmsParams({ ...BASE_LAYER, dimensionValues: { time: date } }),
+      ).toMatchObject({ TIME: "2023-06-15T12:00:00.000Z" });
+    });
+  });
+
+  describe("customParams", () => {
+    it("spreads customParams as-is into the result", () => {
+      expect(
+        buildWmsParams({
+          ...BASE_LAYER,
+          customParams: { COLORSCALERANGE: "-2,35", LOGSCALE: "false" },
+        }),
+      ).toMatchObject({ COLORSCALERANGE: "-2,35", LOGSCALE: "false" });
+    });
+
+    it("omits nothing when customParams is absent", () => {
+      const result = buildWmsParams(BASE_LAYER);
+      expect(result).not.toHaveProperty("COLORSCALERANGE");
+      expect(result).not.toHaveProperty("LOGSCALE");
+    });
+
+    it("customParams can override standard params", () => {
+      // Explicit vendor override takes precedence over the derived STYLES value
+      expect(
+        buildWmsParams({
+          ...BASE_LAYER,
+          style: "boxfill/rainbow",
+          customParams: { STYLES: "contour" },
+        }),
+      ).toMatchObject({ STYLES: "contour" });
+    });
+  });
+});

--- a/packages/openlayers/lib/map/wms-params.ts
+++ b/packages/openlayers/lib/map/wms-params.ts
@@ -21,5 +21,6 @@ export function buildWmsParams(
           v instanceof Date ? v.toISOString() : v,
         ]),
       )),
+    ...(layerModel.customParams ?? {}),
   };
 }


### PR DESCRIPTION
Allows passing arbitrary key-value pairs to WMS GetMap requests, intended for non-standard server extensions such as NcWMS (COLORSCALERANGE, LOGSCALE).