### PR TITLE
feat: expose layer id in map-layer-state-change and map-state-change events

### DIFF
--- a/packages/core/lib/model/events.ts
+++ b/packages/core/lib/model/events.ts
@@ -41,6 +41,7 @@ export interface MapLayerStateChangeEvent {
   type: typeof MapLayerStateChangeEventType;
   layerState: ResolvedMapLayerState;
   layerIndex: number;
+  layerId?: string | number;
 }
 
 export const MapStateChangeEventType = "map-state-change";

--- a/packages/core/lib/model/resolved-map-state.ts
+++ b/packages/core/lib/model/resolved-map-state.ts
@@ -27,9 +27,14 @@ export interface MapLayerDataInfo {
   geometryTypes?: Array<"Point" | "LineString" | "Polygon">;
 }
 
+export interface ResolvedMapLayerIdentity {
+  id?: string | number;
+}
+
 export type ResolvedMapLayerState = MapLayerCreationStatus &
   MapLayerLoadingStatus &
-  MapLayerDataInfo;
+  MapLayerDataInfo &
+  ResolvedMapLayerIdentity;
 
 /**
  * Describes the actual view state of a map

--- a/packages/openlayers/lib/map/layer-update.ts
+++ b/packages/openlayers/lib/map/layer-update.ts
@@ -77,6 +77,9 @@ export function updateLayerProperties(
     // any other case: apply the property
     return true;
   }
+  if (!previousLayerModel && layerModel.id !== undefined) {
+    olLayer.set(`${GEOSPATIAL_SDK_PREFIX}layer-id`, layerModel.id);
+  }
   if (shouldApplyProperty("visibility")) {
     olLayer.setVisible(layerModel.visibility!);
   }

--- a/packages/openlayers/lib/map/listen.test.ts
+++ b/packages/openlayers/lib/map/listen.test.ts
@@ -350,6 +350,28 @@ describe("event listener registration", () => {
     });
 
     describe("layer loading & data info", () => {
+      it("includes layerId in the event when the layer has an id", async () => {
+        await resetMapFromContext(map, {
+          layers: [{ ...MAP_CTX_LAYER_XYZ_FIXTURE, id: "my-layer" }],
+          view: null,
+        });
+        await vi.runAllTimersAsync();
+        callback.mockClear();
+
+        const layer = map.getLayers().item(0);
+        layer.dispatchEvent({
+          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+          layerState: { loaded: true },
+        } as unknown as BaseEvent);
+
+        expect(callback).toHaveBeenCalledWith({
+          layerState: { created: true, loaded: true },
+          layerIndex: 0,
+          layerId: "my-layer",
+          type: "map-layer-state-change",
+        });
+      });
+
       it("transmits updated layer state as they update", async () => {
         await resetMapFromContext(map, {
           layers: [MAP_CTX_LAYER_XYZ_FIXTURE, MAP_CTX_LAYER_WMS_FIXTURE],
@@ -838,6 +860,31 @@ describe("event listener registration", () => {
             resolution: 1,
             scaleDenominator: 3571.428571428571,
           },
+        },
+      });
+    });
+
+    it("includes layer id in mapState.layers when the layer has an id", async () => {
+      await resetMapFromContext(map, {
+        layers: [{ ...MAP_CTX_LAYER_XYZ_FIXTURE, id: "my-layer" }],
+        view: null,
+      });
+      await vi.runAllTimersAsync();
+      callback.mockClear();
+
+      map
+        .getLayers()
+        .item(0)
+        .dispatchEvent({
+          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+          layerState: { loaded: true },
+        } as unknown as BaseEvent);
+
+      expect(callback).toHaveBeenCalledWith({
+        type: "map-state-change",
+        mapState: {
+          layers: [{ created: true, loaded: true, id: "my-layer" }],
+          view: null,
         },
       });
     });

--- a/packages/openlayers/lib/map/register-events.ts
+++ b/packages/openlayers/lib/map/register-events.ts
@@ -107,6 +107,10 @@ export function propagateLayerStateChangeEventToMap(
       return;
     }
     const layerIndex = map.getLayers().getArray().indexOf(layer);
+    const layerId = layer.get(`${GEOSPATIAL_SDK_PREFIX}layer-id`) as
+      | string
+      | number
+      | undefined;
     map.dispatchEvent({
       type: `${GEOSPATIAL_SDK_PREFIX}${MapLayerStateChangeEventType}`,
       layerState: {
@@ -114,6 +118,7 @@ export function propagateLayerStateChangeEventToMap(
         ...currentLoadingStatus,
       },
       layerIndex,
+      ...(layerId !== undefined ? { layerId } : {}),
     } as unknown as BaseEvent);
   }
 
@@ -219,7 +224,10 @@ export function registerMapStateChangeEvent(map: Map) {
     `${GEOSPATIAL_SDK_PREFIX}${MapLayerStateChangeEventType}`,
     (event: BaseEvent & MapLayerStateChangeEvent) => {
       const layers = [...currentState.layers];
-      layers[event.layerIndex] = event.layerState;
+      layers[event.layerIndex] = {
+        ...event.layerState,
+        ...(event.layerId !== undefined ? { id: event.layerId } : {}),
+      };
       currentState = { ...currentState, layers };
       emitState();
     },


### PR DESCRIPTION
When a `MapContextLayer` has an `id`, it is now propagated to:
- `MapLayerStateChangeEvent.layerId`
- `ResolvedMapLayerState.id` (visible in `MapStateChangeEvent.mapState.layers`)

This will allow for a stronger reconciliation between the state and the context.