### PR TITLE
fix(legend): use capabilities LegendURL for WMS legends

### DIFF
--- a/packages/legend/lib/create-legend/from-layer.test.ts
+++ b/packages/legend/lib/create-legend/from-layer.test.ts
@@ -4,10 +4,16 @@ import {
   MapContextLayerWms,
   MapContextLayerWmts,
 } from "@geospatial-sdk/core";
-import { WmtsEndpoint } from "@camptocamp/ogc-client";
+import { WmsEndpoint, WmtsEndpoint } from "@camptocamp/ogc-client";
 
-// Mock dependencies
+// Mock dependencies. Both endpoints default to advertising no legend, so WMS
+// falls back to a GetLegendGraphic request unless a test says otherwise.
 vi.mock("@camptocamp/ogc-client", () => ({
+  WmsEndpoint: class WmsMock {
+    isReady() {
+      return Promise.resolve({ getLayerByName: () => null });
+    }
+  },
   WmtsEndpoint: class WmtsMock {
     isReady() {}
   },
@@ -139,6 +145,59 @@ describe("createLegendFromLayer", () => {
     const img = (result as HTMLElement).querySelector("img");
 
     expect(img?.src).toContain("STYLE=my_custom_style");
+  });
+
+  it("prefers the LegendURL advertised in WMS capabilities", async () => {
+    const mockLegendUrl = "https://example.com/wms-legend.png";
+    vi.spyOn(WmsEndpoint.prototype, "isReady").mockResolvedValue({
+      getLayerByName: () => ({ styles: [{ legendUrl: mockLegendUrl }] }),
+    } as unknown as WmsEndpoint);
+
+    const result = await createLegendFromLayer(baseWmsLayer);
+    const img = (result as HTMLElement).querySelector("img");
+
+    expect(img?.src).toBe(mockLegendUrl);
+  });
+
+  it("uses matching style LegendURL for WMS layer when layer.style is set", async () => {
+    vi.spyOn(WmsEndpoint.prototype, "isReady").mockResolvedValue({
+      getLayerByName: () => ({
+        styles: [
+          { name: "default", legendUrl: "https://example.com/default.png" },
+          { name: "night", legendUrl: "https://example.com/night.png" },
+        ],
+      }),
+    } as unknown as WmsEndpoint);
+
+    const result = await createLegendFromLayer({
+      ...baseWmsLayer,
+      style: "night",
+    });
+    const img = (result as HTMLElement).querySelector("img");
+
+    expect(img?.src).toBe("https://example.com/night.png");
+  });
+
+  it("falls back to GetLegendGraphic when WMS capabilities advertise no legend", async () => {
+    vi.spyOn(WmsEndpoint.prototype, "isReady").mockResolvedValue({
+      getLayerByName: () => ({ styles: [] }),
+    } as unknown as WmsEndpoint);
+
+    const result = await createLegendFromLayer(baseWmsLayer);
+    const img = (result as HTMLElement).querySelector("img");
+
+    expect(img?.src).toContain("REQUEST=GetLegendGraphic");
+  });
+
+  it("falls back to GetLegendGraphic when WMS capabilities cannot be read", async () => {
+    vi.spyOn(WmsEndpoint.prototype, "isReady").mockRejectedValue(
+      new Error("network"),
+    );
+
+    const result = await createLegendFromLayer(baseWmsLayer);
+    const img = (result as HTMLElement).querySelector("img");
+
+    expect(img?.src).toContain("REQUEST=GetLegendGraphic");
   });
 
   it("creates a legend for a valid WMTS layer with legend URL", async () => {

--- a/packages/legend/lib/create-legend/from-layer.test.ts
+++ b/packages/legend/lib/create-legend/from-layer.test.ts
@@ -178,6 +178,26 @@ describe("createLegendFromLayer", () => {
     expect(img?.src).toBe("https://example.com/night.png");
   });
 
+  it("falls back to GetLegendGraphic honouring STYLE when the requested WMS style has no advertised legend", async () => {
+    vi.spyOn(WmsEndpoint.prototype, "isReady").mockResolvedValue({
+      getLayerByName: () => ({
+        styles: [
+          { name: "default", legendUrl: "https://example.com/default.png" },
+        ],
+      }),
+    } as unknown as WmsEndpoint);
+
+    const result = await createLegendFromLayer({
+      ...baseWmsLayer,
+      style: "night",
+    });
+    const img = (result as HTMLElement).querySelector("img");
+
+    expect(img?.src).toContain("REQUEST=GetLegendGraphic");
+    expect(img?.src).toContain("STYLE=night");
+    expect(img?.src).not.toContain("default.png");
+  });
+
   it("falls back to GetLegendGraphic when WMS capabilities advertise no legend", async () => {
     vi.spyOn(WmsEndpoint.prototype, "isReady").mockResolvedValue({
       getLayerByName: () => ({ styles: [] }),

--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -17,15 +17,23 @@ interface LegendOptions {
 
 /**
  * Pick the legend URL advertised for a layer's styles in the service
- * capabilities, preferring the requested style and falling back to the first.
+ * capabilities, preferring the requested style.
+ *
+ * When a specific style is requested but no matching style advertises a legend,
+ * `fallbackToFirstStyle` decides whether to use the first advertised legend
+ * (the best a WMTS layer can do) or to give up so the caller can honour the
+ * requested style another way (a WMS `GetLegendGraphic&STYLE=...` request).
  *
  * @param styles - The styles advertised for the layer.
  * @param requestedStyle - The style requested on the layer, if any.
+ * @param fallbackToFirstStyle - Use the first style's legend when the requested
+ *   style has none. Defaults to `true`.
  * @returns The advertised legend URL, or `null` if none is available.
  */
 function findStyleLegendUrl(
   styles: { name?: string; legendUrl?: string }[] | undefined,
   requestedStyle?: string,
+  fallbackToFirstStyle = true,
 ): string | null {
   if (!styles || styles.length === 0) {
     return null;
@@ -34,6 +42,9 @@ function findStyleLegendUrl(
     const matchingStyle = styles.find((s) => s.name === requestedStyle);
     if (matchingStyle?.legendUrl) {
       return matchingStyle.legendUrl;
+    }
+    if (!fallbackToFirstStyle) {
+      return null;
     }
   }
   return styles[0].legendUrl ?? null;
@@ -79,6 +90,7 @@ async function createWmsLegendUrl(
     const advertisedLegendUrl = findStyleLegendUrl(
       layerByName?.styles,
       layer.style,
+      false,
     );
     if (advertisedLegendUrl) {
       return advertisedLegendUrl;

--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -38,15 +38,18 @@ function findStyleLegendUrl(
   if (!styles || styles.length === 0) {
     return null;
   }
+
   if (requestedStyle) {
     const matchingStyle = styles.find((s) => s.name === requestedStyle);
     if (matchingStyle?.legendUrl) {
       return matchingStyle.legendUrl;
     }
+
     if (!fallbackToFirstStyle) {
       return null;
     }
   }
+
   return styles[0].legendUrl ?? null;
 }
 
@@ -92,6 +95,7 @@ async function createWmsLegendUrl(
       layer.style,
       false,
     );
+
     if (advertisedLegendUrl) {
       return advertisedLegendUrl;
     }
@@ -99,7 +103,7 @@ async function createWmsLegendUrl(
     // Capabilities unavailable; fall back to a GetLegendGraphic request.
   }
 
-  return buildGetLegendGraphicUrl(layer, options).toString();
+  return buildWmsGetLegendGraphicUrl(layer, options).toString();
 }
 
 /**
@@ -109,7 +113,7 @@ async function createWmsLegendUrl(
  * @param options - Optional configuration for legend generation
  * @returns A URL for the WMS legend graphic
  */
-function buildGetLegendGraphicUrl(
+function buildWmsGetLegendGraphicUrl(
   layer: MapContextLayerWms,
   options: LegendOptions = {},
 ): URL {

--- a/packages/legend/lib/create-legend/from-layer.ts
+++ b/packages/legend/lib/create-legend/from-layer.ts
@@ -4,7 +4,7 @@ import {
   MapContextLayerWmts,
   removeSearchParams,
 } from "@geospatial-sdk/core";
-import { WmtsEndpoint } from "@camptocamp/ogc-client";
+import { WmsEndpoint, WmtsEndpoint } from "@camptocamp/ogc-client";
 
 /**
  * Configuration options for legend generation
@@ -13,6 +13,30 @@ interface LegendOptions {
   format?: string;
   widthPxHint?: number;
   heightPxHint?: number;
+}
+
+/**
+ * Pick the legend URL advertised for a layer's styles in the service
+ * capabilities, preferring the requested style and falling back to the first.
+ *
+ * @param styles - The styles advertised for the layer.
+ * @param requestedStyle - The style requested on the layer, if any.
+ * @returns The advertised legend URL, or `null` if none is available.
+ */
+function findStyleLegendUrl(
+  styles: { name?: string; legendUrl?: string }[] | undefined,
+  requestedStyle?: string,
+): string | null {
+  if (!styles || styles.length === 0) {
+    return null;
+  }
+  if (requestedStyle) {
+    const matchingStyle = styles.find((s) => s.name === requestedStyle);
+    if (matchingStyle?.legendUrl) {
+      return matchingStyle.legendUrl;
+    }
+  }
+  return styles[0].legendUrl ?? null;
 }
 
 /**
@@ -32,13 +56,48 @@ export function hasLegendSupport(
 }
 
 /**
- * Create a legend URL for a WMS layer
+ * Create a legend URL for a WMS layer.
+ *
+ * Prefers the legend advertised in the service capabilities (the canonical,
+ * styled graphic), the same way the WMTS path does. Falls back to building a
+ * `GetLegendGraphic` request only when capabilities advertise no legend (e.g.
+ * QGIS Server) or cannot be read. This matters for servers such as the IGN
+ * Géoplateforme, which advertise a static `LegendURL` and reject
+ * `GetLegendGraphic` requests outright.
+ *
+ * @param layer - The MapContextLayer to create a legend URL for
+ * @param options - Optional configuration for legend generation
+ * @returns A URL for the WMS legend graphic, or `null` if none is available
+ */
+async function createWmsLegendUrl(
+  layer: MapContextLayerWms,
+  options: LegendOptions = {},
+): Promise<string | null> {
+  try {
+    const endpoint = await new WmsEndpoint(layer.url).isReady();
+    const layerByName = endpoint.getLayerByName(layer.name);
+    const advertisedLegendUrl = findStyleLegendUrl(
+      layerByName?.styles,
+      layer.style,
+    );
+    if (advertisedLegendUrl) {
+      return advertisedLegendUrl;
+    }
+  } catch {
+    // Capabilities unavailable; fall back to a GetLegendGraphic request.
+  }
+
+  return buildGetLegendGraphicUrl(layer, options).toString();
+}
+
+/**
+ * Build a WMS `GetLegendGraphic` request URL from a layer's base URL.
  *
  * @param layer - The MapContextLayer to create a legend URL for
  * @param options - Optional configuration for legend generation
  * @returns A URL for the WMS legend graphic
  */
-function createWmsLegendUrl(
+function buildGetLegendGraphicUrl(
   layer: MapContextLayerWms,
   options: LegendOptions = {},
 ): URL {
@@ -94,23 +153,7 @@ async function createWmtsLegendUrl(
     );
   }
 
-  if (layerByName.styles && layerByName.styles.length > 0) {
-    // If a specific style is requested, find its legend URL
-    if (layer.style) {
-      const matchingStyle = layerByName.styles.find(
-        (s: { name?: string }) => s.name === layer.style,
-      );
-      if (matchingStyle?.legendUrl) {
-        return matchingStyle.legendUrl;
-      }
-    }
-    // Fall back to the first style's legend URL
-    if (layerByName.styles[0].legendUrl) {
-      return layerByName.styles[0].legendUrl;
-    }
-  }
-
-  return null;
+  return findStyleLegendUrl(layerByName.styles, layer.style);
 }
 
 /**
@@ -161,7 +204,7 @@ export async function createLegendFromLayer(
 
     // Determine legend URL based on layer type
     if (layer.type === "wms") {
-      legendUrl = createWmsLegendUrl(layer, options).toString();
+      legendUrl = await createWmsLegendUrl(layer, options);
     } else if (layer.type === "wmts") {
       legendUrl = await createWmtsLegendUrl(layer);
     }


### PR DESCRIPTION
## Why

WMS legends were always built as `GetLegendGraphic` requests, ignoring the `LegendURL` advertised in service capabilities. Some servers (e.g.https://data.geopf.fr/wms-r/wms) advertise a static `LegendURL` and reject `GetLegendGraphic` outright, so their legends came back broken.

## What

WMS legends now prefer the legend advertised in the capabilities — the canonical, styled graphic — matching how the WMTS path already works. `GetLegendGraphic` is used only as a fallback when capabilities advertise no legend or cannot be read.

## How

- Extract the shared "pick a style's legend URL" logic into `findStyleLegendUrl`, used by both the WMS and WMTS paths.
- `createWmsLegendUrl` now reads the WMS capabilities and returns the advertised LegendURL` for the requested style; on miss it falls back to `buildWmsGetLegendGraphicUrl` (the former `GetLegendGraphic` builder), preserving the requested `STYLE`.
- A `fallbackToFirstStyle` flag lets WMTS use the first advertised legend while WMS declines, so the requested style can still be honoured via `GetLegendGraphic`.
