### PR TITLE
Better handle sequential updates to a map

### DIFF
--- a/packages/core/fixtures/map-context.fixtures.ts
+++ b/packages/core/fixtures/map-context.fixtures.ts
@@ -149,3 +149,13 @@ export const SAMPLE_LAYER5: MapContextLayerXyz = deepFreeze({
   url: "http://my.tiles/server",
   label: "My XYZ Layer",
 });
+export const SAMPLE_LAYER6: MapContextLayerGeotiff = deepFreeze({
+  type: "geotiff",
+  url: "http://my.tiles/cog",
+  label: "My COG Layer",
+});
+export const SAMPLE_LAYER7: MapContextLayerMapLibreStyle = deepFreeze({
+  type: "maplibre-style",
+  styleUrl: "http://my.tiles/style.json",
+  label: "My MapLibre Style Layer",
+});

--- a/packages/core/lib/utils/map-context-diff.test.ts
+++ b/packages/core/lib/utils/map-context-diff.test.ts
@@ -7,6 +7,8 @@ import {
   SAMPLE_LAYER3,
   SAMPLE_LAYER4,
   SAMPLE_LAYER5,
+  SAMPLE_LAYER6,
+  SAMPLE_LAYER7,
 } from "../../fixtures/map-context.fixtures.js";
 import { beforeEach, describe, expect, it } from "vitest";
 
@@ -387,6 +389,115 @@ describe("Context diff utils", () => {
           viewChanges: {
             extent: [0, 1, 2, 3],
           },
+        });
+      });
+    });
+
+    describe("combined changes (2)", () => {
+      beforeEach(() => {
+        contextOld = {
+          ...SAMPLE_CONTEXT,
+          layers: [
+            SAMPLE_LAYER1,
+            SAMPLE_LAYER5,
+            SAMPLE_LAYER3,
+            SAMPLE_LAYER4,
+            SAMPLE_LAYER6,
+          ],
+        };
+        contextNew = {
+          ...SAMPLE_CONTEXT,
+          layers: [SAMPLE_LAYER3, SAMPLE_LAYER1],
+        };
+      });
+      it("outputs the correct diff", async () => {
+        diff = computeMapContextDiff(contextNew, contextOld);
+        expect(diff).toEqual({
+          layersAdded: [],
+          layersChanged: [],
+          layersRemoved: [
+            {
+              layer: SAMPLE_LAYER5,
+              position: 1,
+            },
+            {
+              layer: SAMPLE_LAYER4,
+              position: 3,
+            },
+            {
+              layer: SAMPLE_LAYER6,
+              position: 4,
+            },
+          ],
+          layersReordered: [
+            {
+              layer: SAMPLE_LAYER3,
+              newPosition: 0,
+              previousPosition: 1,
+            },
+            {
+              layer: SAMPLE_LAYER1,
+              newPosition: 1,
+              previousPosition: 0,
+            },
+          ],
+        });
+      });
+    });
+
+    describe("combined changes (3)", () => {
+      beforeEach(() => {
+        contextOld = {
+          ...SAMPLE_CONTEXT,
+          layers: [SAMPLE_LAYER5, SAMPLE_LAYER1, SAMPLE_LAYER2],
+        };
+        contextNew = {
+          ...SAMPLE_CONTEXT,
+          layers: [
+            SAMPLE_LAYER2,
+            SAMPLE_LAYER3,
+            SAMPLE_LAYER6,
+            SAMPLE_LAYER1,
+            SAMPLE_LAYER7,
+          ],
+        };
+      });
+      it("outputs the correct diff", async () => {
+        diff = computeMapContextDiff(contextNew, contextOld);
+        expect(diff).toEqual({
+          layersAdded: [
+            {
+              layer: SAMPLE_LAYER3,
+              position: 1,
+            },
+            {
+              layer: SAMPLE_LAYER6,
+              position: 2,
+            },
+            {
+              layer: SAMPLE_LAYER7,
+              position: 4,
+            },
+          ],
+          layersChanged: [],
+          layersRemoved: [
+            {
+              layer: SAMPLE_LAYER5,
+              position: 0,
+            },
+          ],
+          layersReordered: [
+            {
+              layer: SAMPLE_LAYER2,
+              previousPosition: 3,
+              newPosition: 0,
+            },
+            {
+              layer: SAMPLE_LAYER1,
+              previousPosition: 0,
+              newPosition: 3,
+            },
+          ],
         });
       });
     });

--- a/packages/core/lib/utils/map-context-diff.ts
+++ b/packages/core/lib/utils/map-context-diff.ts
@@ -72,21 +72,25 @@ export function computeMapContextDiff(
     }
   }
 
-  // look for moved layers
-  const prevLayersFiltered = previousContext.layers.filter(
+  // look for moved layers (ignore removed and added ones)
+  const movedLayersInPrevious = previousContext.layers.filter(
     (l) => !layersRemoved.find(({ layer }) => l === layer),
   );
-  const nextLayersFiltered = nextContext.layers.filter(
+  const movedLayersInNext = nextContext.layers.filter(
     (l) => !layersAdded.find(({ layer }) => l === layer),
   );
-  for (let i = 0; i < nextLayersFiltered.length; i++) {
-    const layer = nextLayersFiltered[i];
-    const prevPosition = getLayerPosition(layer, prevLayersFiltered);
+  for (let i = 0; i < movedLayersInNext.length; i++) {
+    const layer = movedLayersInNext[i];
+    let prevPosition = getLayerPosition(layer, movedLayersInPrevious);
     if (i !== prevPosition) {
+      // shift prevPosition of a move layer when others layers were added before them
+      for (const { position: addedPos } of layersAdded) {
+        if (addedPos <= prevPosition) prevPosition++;
+      }
       layersReordered.push({
         layer,
         newPosition: getLayerPosition(layer, nextContext.layers),
-        previousPosition: getLayerPosition(layer, previousContext.layers),
+        previousPosition: prevPosition,
       });
     }
   }

--- a/packages/elements/lib/map-element.ts
+++ b/packages/elements/lib/map-element.ts
@@ -28,22 +28,19 @@ export class SdkMapElement extends LitElement {
   private map: OlMap | null = null;
 
   public async firstUpdated() {
-    this.map = await createMapFromContext(this.context, this.mapElement);
+    this.map = createMapFromContext(this.context, this.mapElement);
   }
 
   public async updated(changedProperties: PropertyValues<this>) {
     if (changedProperties.has("context")) {
-      await this.contextHasChanged(
-        changedProperties.get("context"),
-        this.context,
-      );
+      this.contextHasChanged(changedProperties.get("context"), this.context);
     }
   }
 
-  async contextHasChanged(value: MapContext | undefined, oldValue: MapContext) {
+  contextHasChanged(value: MapContext | undefined, oldValue: MapContext) {
     if (!this.map || !value) return;
     const diff = computeMapContextDiff(value, oldValue);
-    await applyContextDiffToMap(this.map, diff);
+    applyContextDiffToMap(this.map, diff);
   }
 
   render() {

--- a/packages/maplibre/lib/map/apply-context-diff.test.ts
+++ b/packages/maplibre/lib/map/apply-context-diff.test.ts
@@ -14,7 +14,7 @@ import {
 } from "@geospatial-sdk/core/fixtures/map-context.fixtures.js";
 import { applyContextDiffToMap } from "./apply-context-diff.js";
 import { generateLayerHashWithoutUpdatableProps } from "../helpers/map.helpers.js";
-import { resetMapFromContext } from "./create-map.js";
+import { getMapUpdatesPromise, resetMapFromContext } from "./create-map.js";
 import { MockInstance } from "vitest";
 
 // Helper to create a fresh mock Map instance for each test
@@ -23,6 +23,7 @@ function createMockMap(): MapLibreMap {
     layers: [] as any[],
     source: {} as any,
   };
+  const globalState: Record<string, unknown> = {};
   return {
     addLayer: vi.fn((layer, beforeId) => {
       if (beforeId) {
@@ -77,6 +78,9 @@ function createMockMap(): MapLibreMap {
     }),
     setLayoutProperty: vi.fn(),
     setPaintProperty: vi.fn(),
+    getGlobalState: () => globalState,
+    setGlobalStateProperty: (name: string, value: unknown) =>
+      (globalState[name] = value),
   } as unknown as MapLibreMap;
 }
 
@@ -99,7 +103,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
       layersRemoved: [],
       layersReordered: [],
     };
-    await applyContextDiffToMap(map, diff);
+    applyContextDiffToMap(map, diff);
+    await getMapUpdatesPromise(map);
     expect(map.addLayer).not.toHaveBeenCalled();
     expect(map.addSource).not.toHaveBeenCalled();
     expect(map.removeLayer).not.toHaveBeenCalled();
@@ -116,7 +121,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
       layersRemoved: [],
       layersReordered: [],
     };
-    await applyContextDiffToMap(map, diff);
+    applyContextDiffToMap(map, diff);
+    await getMapUpdatesPromise(map);
     expect(map.addSource).toHaveBeenCalled();
     expect(map.addLayer).toHaveBeenCalled();
   });
@@ -126,7 +132,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
       ...SAMPLE_CONTEXT,
       layers: [SAMPLE_LAYER2, SAMPLE_LAYER1],
     };
-    await resetMapFromContext(map, context);
+    resetMapFromContext(map, context);
+    await getMapUpdatesPromise(map);
     diff = {
       layersAdded: [],
       layersChanged: [],
@@ -140,7 +147,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
       .layers[1] as RasterLayerSpecification;
     const layer2: RasterLayerSpecification = map.getStyle()
       .layers[0] as RasterLayerSpecification;
-    await applyContextDiffToMap(map, diff);
+    applyContextDiffToMap(map, diff);
+    await getMapUpdatesPromise(map);
     expect(map.removeLayer).toHaveBeenCalledWith(layer1.id);
     expect(map.removeLayer).toHaveBeenCalledWith(layer2.id);
     expect(map.removeSource).toHaveBeenCalledWith(layer1.source);
@@ -154,7 +162,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
         ...SAMPLE_CONTEXT,
         layers: [SAMPLE_LAYER3, SAMPLE_LAYER1],
       };
-      await resetMapFromContext(map, context);
+      resetMapFromContext(map, context);
+      await getMapUpdatesPromise(map);
       vi.clearAllMocks();
 
       // this is to get reliable source ids
@@ -197,7 +206,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
         layersRemoved: [],
         layersReordered: [],
       };
-      await applyContextDiffToMap(map, diff);
+      applyContextDiffToMap(map, diff);
+      await getMapUpdatesPromise(map);
 
       expect(map.addLayer).toHaveBeenCalledTimes(4); // 3 for vector layer, 1 for raster layer
       expect(map.removeLayer).toHaveBeenCalledTimes(4); // same as above
@@ -272,7 +282,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
         layersRemoved: [],
         layersReordered: [],
       };
-      await applyContextDiffToMap(map, diff);
+      applyContextDiffToMap(map, diff);
+      await getMapUpdatesPromise(map);
 
       expect(map.setLayoutProperty).toHaveBeenCalledTimes(3); // 3 for vector layer
       expect(map.setPaintProperty).toHaveBeenCalledTimes(1);
@@ -315,7 +326,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
       layersReordered: [],
       viewChanges: { extent: [-10, -10, 20, 20] },
     };
-    await applyContextDiffToMap(map, diff);
+    applyContextDiffToMap(map, diff);
+    await getMapUpdatesPromise(map);
     expect(map.fitBounds).toHaveBeenCalledWith(
       [
         [-10, -10],
@@ -333,7 +345,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
       layersReordered: [],
       viewChanges: { center: [2.35, 48.86], zoom: 12 },
     };
-    await applyContextDiffToMap(map, diff);
+    applyContextDiffToMap(map, diff);
+    await getMapUpdatesPromise(map);
     expect(map.setCenter).toHaveBeenCalledWith([2.35, 48.86]);
     expect(map.setZoom).toHaveBeenCalledWith(12);
     expect(map.fitBounds).not.toHaveBeenCalled();
@@ -347,7 +360,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
       layersReordered: [],
       viewChanges: { center: [2.35, 48.86] },
     };
-    await applyContextDiffToMap(map, diff);
+    applyContextDiffToMap(map, diff);
+    await getMapUpdatesPromise(map);
     expect(map.setCenter).toHaveBeenCalledWith([2.35, 48.86]);
     expect(map.setZoom).not.toHaveBeenCalled();
     expect(map.fitBounds).not.toHaveBeenCalled();
@@ -360,7 +374,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
           ...SAMPLE_CONTEXT,
           layers: [SAMPLE_LAYER1, SAMPLE_LAYER3, SAMPLE_LAYER2],
         };
-        await resetMapFromContext(map, context);
+        resetMapFromContext(map, context);
+        await getMapUpdatesPromise(map);
         vi.clearAllMocks();
 
         diff = {
@@ -380,7 +395,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
             },
           ],
         };
-        await applyContextDiffToMap(map, diff);
+        applyContextDiffToMap(map, diff);
+        await getMapUpdatesPromise(map);
       });
       it("moves the layers accordingly", () => {
         expect(map.getStyle().layers.length).toBe(5);
@@ -433,7 +449,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
           ...SAMPLE_CONTEXT,
           layers: [layer1WithId, SAMPLE_LAYER3, layer4WithStyle, SAMPLE_LAYER2],
         };
-        await resetMapFromContext(map, context);
+        resetMapFromContext(map, context);
+        await getMapUpdatesPromise(map);
         vi.clearAllMocks();
 
         diff = {
@@ -463,7 +480,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
             },
           ],
         };
-        await applyContextDiffToMap(map, diff);
+        applyContextDiffToMap(map, diff);
+        await getMapUpdatesPromise(map);
       });
       it("moves the layers accordingly", () => {
         expect(map.getStyle().layers.length).toBe(8);
@@ -522,7 +540,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
         ...SAMPLE_CONTEXT,
         layers: [SAMPLE_LAYER1, SAMPLE_LAYER5, SAMPLE_LAYER3, SAMPLE_LAYER4],
       };
-      await resetMapFromContext(map, context);
+      resetMapFromContext(map, context);
+      await getMapUpdatesPromise(map);
       vi.clearAllMocks();
 
       diff = {
@@ -562,7 +581,8 @@ describe("applyContextDiffToMap (mocked Map)", () => {
           },
         ],
       };
-      await applyContextDiffToMap(map, diff);
+      applyContextDiffToMap(map, diff);
+      await getMapUpdatesPromise(map);
     });
 
     it("moves the layers accordingly", () => {

--- a/packages/maplibre/lib/map/apply-context-diff.ts
+++ b/packages/maplibre/lib/map/apply-context-diff.ts
@@ -6,7 +6,7 @@ import {
   getFirstLayerIdAtPosition,
   getLayersAtPosition,
   getLayersFromContextLayer,
-  updateLayerProperties
+  updateLayerProperties,
 } from "../helpers/map.helpers.js";
 import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
 

--- a/packages/maplibre/lib/map/apply-context-diff.ts
+++ b/packages/maplibre/lib/map/apply-context-diff.ts
@@ -1,13 +1,14 @@
 import { MapContextDiff, MapContextLayer } from "@geospatial-sdk/core";
 import type { Map } from "maplibre-gl";
-import { createLayer } from "./create-map.js";
+import { createLayer, getMapUpdatesPromise } from "./create-map.js";
 import {
   canDoIncrementalUpdate,
   getFirstLayerIdAtPosition,
   getLayersAtPosition,
   getLayersFromContextLayer,
-  updateLayerProperties,
+  updateLayerProperties
 } from "../helpers/map.helpers.js";
+import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
 
 /**
  * This will either update the layers in the map or recreate them;
@@ -56,111 +57,121 @@ export async function updateLayerInMap(
 }
 
 /**
- * Apply a context diff to an MapLibre map
+ * Apply a context diff to an MapLibre map.
+ * The function returns synchronously; all asynchronous modifications are stacked
+ * in a promise chain stored on the map.
  * @param map
  * @param contextDiff
  */
-export async function applyContextDiffToMap(
+export function applyContextDiffToMap(
   map: Map,
   contextDiff: MapContextDiff,
-): Promise<Map> {
-  // removed layers (sorted by descending position)
-  if (contextDiff.layersRemoved.length > 0) {
-    const removed = contextDiff.layersRemoved.sort(
-      (a, b) => b.position - a.position,
-    );
-    for (const layerRemoved of removed) {
-      const mlLayers = getLayersFromContextLayer(map, layerRemoved.layer);
-      if (mlLayers.length === 0) {
-        console.warn(
-          `[Warning] applyContextDiffToMap: no layer found at position ${layerRemoved.position} to remove.`,
-        );
-        continue;
+): Map {
+  const newChain = getMapUpdatesPromise(map).then(async () => {
+    // removed layers (sorted by descending position)
+    if (contextDiff.layersRemoved.length > 0) {
+      const removed = contextDiff.layersRemoved.sort(
+        (a, b) => b.position - a.position,
+      );
+      for (const layerRemoved of removed) {
+        const mlLayers = getLayersFromContextLayer(map, layerRemoved.layer);
+        if (mlLayers.length === 0) {
+          console.warn(
+            `[Warning] applyContextDiffToMap: no layer found at position ${layerRemoved.position} to remove.`,
+          );
+          continue;
+        }
+        const sourceId = mlLayers[0].source;
+        mlLayers.forEach((layer) => {
+          map.removeLayer(layer.id);
+        });
+        map.removeSource(sourceId);
       }
-      const sourceId = mlLayers[0].source;
-      mlLayers.forEach((layer) => {
-        map.removeLayer(layer.id);
+    }
+
+    // insert added layers
+    const newLayers = await Promise.all(
+      contextDiff.layersAdded.map((layerAdded) =>
+        createLayer(layerAdded.layer),
+      ),
+    );
+    newLayers.forEach((style, index) => {
+      if (!style) return;
+      const position = contextDiff.layersAdded[index].position;
+      const beforeId = getFirstLayerIdAtPosition(map, position);
+      Object.keys(style.sources).forEach((sourceId) =>
+        map.addSource(sourceId, style.sources[sourceId]),
+      );
+      style.layers.map((layer) => {
+        map.addLayer(layer, beforeId);
       });
-      map.removeSource(sourceId);
-    }
-  }
-
-  // insert added layers
-  const newLayers = await Promise.all(
-    contextDiff.layersAdded.map((layerAdded) => createLayer(layerAdded.layer)),
-  );
-  newLayers.forEach((style, index) => {
-    if (!style) return;
-    const position = contextDiff.layersAdded[index].position;
-    const beforeId = getFirstLayerIdAtPosition(map, position);
-    Object.keys(style.sources).forEach((sourceId) =>
-      map.addSource(sourceId, style.sources[sourceId]),
-    );
-    style.layers.map((layer) => {
-      map.addLayer(layer, beforeId);
     });
+
+    // handle reordered layers (sorted by ascending new position)
+    if (contextDiff.layersReordered.length > 0) {
+      const reordered = contextDiff.layersReordered.sort(
+        (a, b) => a.newPosition - b.newPosition,
+      );
+
+      // collect all layers to be moved
+      const mlLayersToMove = reordered.map((layerReordered) =>
+        getLayersFromContextLayer(map, layerReordered.layer),
+      );
+
+      // move layers
+      for (let i = 0; i < reordered.length; i++) {
+        const layerReordered = reordered[i];
+        const mlLayers = mlLayersToMove[i];
+        const beforeId = getFirstLayerIdAtPosition(
+          map,
+          layerReordered.newPosition + 1,
+        );
+
+        if (mlLayers[0].id === beforeId) {
+          // layer is already at the right position
+          continue;
+        }
+
+        // then we add the moved the layer to its new position
+        for (const layer of mlLayers) {
+          map.moveLayer(layer.id, beforeId);
+        }
+      }
+    }
+
+    // recreate changed layers
+    for (const layerChanged of contextDiff.layersChanged) {
+      const { layer, previousLayer, position } = layerChanged;
+      await updateLayerInMap(map, layer, previousLayer, position);
+    }
+
+    if (typeof contextDiff.viewChanges !== "undefined") {
+      const { viewChanges } = contextDiff;
+
+      if (viewChanges && "extent" in viewChanges) {
+        const { extent } = viewChanges;
+
+        map.fitBounds(
+          [
+            [extent[0], extent[1]],
+            [extent[2], extent[3]],
+          ],
+          {
+            padding: 20,
+            duration: 1000,
+          },
+        );
+      } else if (viewChanges && "center" in viewChanges) {
+        const { center, zoom } = viewChanges;
+        if (center) map.setCenter(center as [number, number]);
+        if (zoom !== undefined) map.setZoom(zoom);
+      }
+    }
   });
-
-  // handle reordered layers (sorted by ascending new position)
-  if (contextDiff.layersReordered.length > 0) {
-    const reordered = contextDiff.layersReordered.sort(
-      (a, b) => a.newPosition - b.newPosition,
-    );
-
-    // collect all layers to be moved
-    const mlLayersToMove = reordered.map((layerReordered) =>
-      getLayersFromContextLayer(map, layerReordered.layer),
-    );
-
-    // move layers
-    for (let i = 0; i < reordered.length; i++) {
-      const layerReordered = reordered[i];
-      const mlLayers = mlLayersToMove[i];
-      const beforeId = getFirstLayerIdAtPosition(
-        map,
-        layerReordered.newPosition + 1,
-      );
-
-      if (mlLayers[0].id === beforeId) {
-        // layer is already at the right position
-        continue;
-      }
-
-      // then we add the moved the layer to its new position
-      for (const layer of mlLayers) {
-        map.moveLayer(layer.id, beforeId);
-      }
-    }
-  }
-
-  // recreate changed layers
-  for (const layerChanged of contextDiff.layersChanged) {
-    const { layer, previousLayer, position } = layerChanged;
-    await updateLayerInMap(map, layer, previousLayer, position);
-  }
-
-  if (typeof contextDiff.viewChanges !== "undefined") {
-    const { viewChanges } = contextDiff;
-
-    if (viewChanges && "extent" in viewChanges) {
-      const { extent } = viewChanges;
-
-      map.fitBounds(
-        [
-          [extent[0], extent[1]],
-          [extent[2], extent[3]],
-        ],
-        {
-          padding: 20,
-          duration: 1000,
-        },
-      );
-    } else if (viewChanges && "center" in viewChanges) {
-      const { center, zoom } = viewChanges;
-      if (center) map.setCenter(center as [number, number]);
-      if (zoom !== undefined) map.setZoom(zoom);
-    }
-  }
+  map.setGlobalStateProperty(
+    `${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`,
+    newChain,
+  );
 
   return map;
 }

--- a/packages/maplibre/lib/map/constants.ts
+++ b/packages/maplibre/lib/map/constants.ts
@@ -1,0 +1,1 @@
+export const GEOSPATIAL_SDK_PREFIX = "--geospatial-sdk-";

--- a/packages/maplibre/lib/map/create-map.ts
+++ b/packages/maplibre/lib/map/create-map.ts
@@ -1,26 +1,15 @@
-import {
-  MapContext,
-  MapContextLayer,
-  removeSearchParams,
-  ViewByZoomAndCenter,
-} from "@geospatial-sdk/core";
+import { MapContext, MapContextLayer, removeSearchParams, ViewByZoomAndCenter } from "@geospatial-sdk/core";
 
 import { LayerSpecification, Map, MapOptions } from "maplibre-gl";
 import { FeatureCollection, Geometry } from "geojson";
-import {
-  OgcApiEndpoint,
-  WfsEndpoint,
-  WmsEndpoint,
-} from "@camptocamp/ogc-client";
+import { OgcApiEndpoint, WfsEndpoint, WmsEndpoint } from "@camptocamp/ogc-client";
 import {
   createDatasetFromGeoJsonLayer,
   generateLayerHashWithoutUpdatableProps,
-  generateLayerId,
+  generateLayerId
 } from "../helpers/map.helpers.js";
-import {
-  LayerMetadataSpecification,
-  PartialStyleSpecification,
-} from "../maplibre.models.js";
+import { LayerMetadataSpecification, PartialStyleSpecification } from "../maplibre.models.js";
+import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
 
 const featureCollection: FeatureCollection<Geometry | null> = {
   type: "FeatureCollection",
@@ -165,45 +154,65 @@ export async function createLayer(
 }
 
 /**
- * Create a Maplibre map from a context; map options need to be provided
+ * Create a Maplibre map from a context; map options need to be provided.
+ * The function returns synchronously; all asynchronous modifications are stacked
+ * in a promise chain stored on the map.
  * @param context
  * @param mapOptions
  */
-export async function createMapFromContext(
+export function createMapFromContext(
   context: MapContext,
   mapOptions: MapOptions,
-): Promise<Map> {
+): Map {
   const map = new Map(mapOptions);
-  return await resetMapFromContext(map, context);
+  return resetMapFromContext(map, context);
 }
 
 /**
- * Resets a Maplibre map from a context; existing content will be cleared
+ * Resets a Maplibre map from a context; existing content will be cleared.
  * @param map
  * @param context
  */
-export async function resetMapFromContext(
-  map: Map,
-  context: MapContext,
-): Promise<Map> {
+export function resetMapFromContext(map: Map, context: MapContext): Map {
+  const existingChain: Promise<void> =
+    map.getGlobalState()[`${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`] ??
+    Promise.resolve();
   map.setZoom((context.view as ViewByZoomAndCenter).zoom);
   map.setCenter((context.view as ViewByZoomAndCenter).center);
 
-  for (let i = 0; i < context.layers.length; i++) {
-    const layerModel = context.layers[i];
-    const partialMLStyle = await createLayer(layerModel);
-    if (!partialMLStyle) continue;
+  const newChain = existingChain.then(async () => {
+    for (let i = 0; i < context.layers.length; i++) {
+      const layerModel = context.layers[i];
+      const partialMLStyle = await createLayer(layerModel);
+      if (!partialMLStyle) continue;
 
-    if (partialMLStyle.glyphs) {
-      map.setGlyphs(partialMLStyle.glyphs);
+      if (partialMLStyle.glyphs) {
+        map.setGlyphs(partialMLStyle.glyphs);
+      }
+      if (partialMLStyle.sprite) {
+        map.setSprite(partialMLStyle.sprite as string);
+      }
+      Object.keys(partialMLStyle.sources).forEach((sourceId) =>
+        map.addSource(sourceId, partialMLStyle.sources[sourceId]),
+      );
+      partialMLStyle.layers.map((layer) => map.addLayer(layer));
     }
-    if (partialMLStyle.sprite) {
-      map.setSprite(partialMLStyle.sprite as string);
-    }
-    Object.keys(partialMLStyle.sources).forEach((sourceId) =>
-      map.addSource(sourceId, partialMLStyle.sources[sourceId]),
-    );
-    partialMLStyle.layers.map((layer) => map.addLayer(layer));
-  }
+  });
+  map.setGlobalStateProperty(
+    `${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`,
+    newChain,
+  );
+
   return map;
+}
+
+/**
+ * This promise will resolve once all pending modifications are done on the map.
+ * @param map
+ */
+export function getMapUpdatesPromise(map: Map): Promise<void> {
+  return (
+    map.getGlobalState()[`${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`] ??
+    Promise.resolve()
+  );
 }

--- a/packages/maplibre/lib/map/create-map.ts
+++ b/packages/maplibre/lib/map/create-map.ts
@@ -1,14 +1,26 @@
-import { MapContext, MapContextLayer, removeSearchParams, ViewByZoomAndCenter } from "@geospatial-sdk/core";
+import {
+  MapContext,
+  MapContextLayer,
+  removeSearchParams,
+  ViewByZoomAndCenter,
+} from "@geospatial-sdk/core";
 
 import { LayerSpecification, Map, MapOptions } from "maplibre-gl";
 import { FeatureCollection, Geometry } from "geojson";
-import { OgcApiEndpoint, WfsEndpoint, WmsEndpoint } from "@camptocamp/ogc-client";
+import {
+  OgcApiEndpoint,
+  WfsEndpoint,
+  WmsEndpoint,
+} from "@camptocamp/ogc-client";
 import {
   createDatasetFromGeoJsonLayer,
   generateLayerHashWithoutUpdatableProps,
-  generateLayerId
+  generateLayerId,
 } from "../helpers/map.helpers.js";
-import { LayerMetadataSpecification, PartialStyleSpecification } from "../maplibre.models.js";
+import {
+  LayerMetadataSpecification,
+  PartialStyleSpecification,
+} from "../maplibre.models.js";
 import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
 
 const featureCollection: FeatureCollection<Geometry | null> = {

--- a/packages/openlayers/lib/map/apply-context-diff.test.ts
+++ b/packages/openlayers/lib/map/apply-context-diff.test.ts
@@ -1,4 +1,5 @@
 import {
+  computeMapContextDiff,
   MapContext,
   MapContextDiff,
   MapContextLayer,
@@ -12,10 +13,11 @@ import {
   SAMPLE_LAYER5,
 } from "@geospatial-sdk/core/fixtures/map-context.fixtures.js";
 import Map from "ol/Map.js";
-import { createLayer, createMapFromContext } from "./create-map.js";
+import { createMapFromContext, getMapUpdatesPromise } from "./create-map.js";
 import { applyContextDiffToMap } from "./apply-context-diff.js";
 import { beforeEach } from "vitest";
 import BaseLayer from "ol/layer/Base.js";
+import { createLayer } from "./layer-creation.js";
 
 async function assertEqualsToModel(layer: any, layerModel: MapContextLayer) {
   const reference = (await createLayer(layerModel)) as any;
@@ -38,12 +40,12 @@ describe("applyContextDiffToMap", () => {
   let map: Map;
   let layersArray: BaseLayer[];
 
-  beforeEach(async () => {
+  beforeEach(() => {
     context = {
       ...SAMPLE_CONTEXT,
       layers: [SAMPLE_LAYER2, SAMPLE_LAYER1],
     };
-    map = await createMapFromContext(context);
+    map = createMapFromContext(context);
   });
 
   describe("no change", () => {
@@ -54,13 +56,14 @@ describe("applyContextDiffToMap", () => {
         layersRemoved: [],
         layersReordered: [],
       };
-      await applyContextDiffToMap(map, diff);
+      applyContextDiffToMap(map, diff);
+      await getMapUpdatesPromise(map);
       layersArray = map.getLayers().getArray();
     });
-    it("does not affect the map", () => {
+    it("does not affect the map", async () => {
       expect(layersArray.length).toEqual(2);
-      assertEqualsToModel(layersArray[0], SAMPLE_LAYER2);
-      assertEqualsToModel(layersArray[1], SAMPLE_LAYER1);
+      await assertEqualsToModel(layersArray[0], SAMPLE_LAYER2);
+      await assertEqualsToModel(layersArray[1], SAMPLE_LAYER1);
     });
   });
 
@@ -81,20 +84,21 @@ describe("applyContextDiffToMap", () => {
         layersRemoved: [],
         layersReordered: [],
       };
-      await applyContextDiffToMap(map, diff);
+      applyContextDiffToMap(map, diff);
+      await getMapUpdatesPromise(map);
       layersArray = map.getLayers().getArray();
     });
-    it("adds the layers to the map", () => {
+    it("adds the layers to the map", async () => {
       expect(layersArray.length).toEqual(4);
-      assertEqualsToModel(layersArray[0], SAMPLE_LAYER3);
-      assertEqualsToModel(layersArray[1], SAMPLE_LAYER2);
-      assertEqualsToModel(layersArray[2], SAMPLE_LAYER4);
-      assertEqualsToModel(layersArray[3], SAMPLE_LAYER1);
+      await assertEqualsToModel(layersArray[0], SAMPLE_LAYER3);
+      await assertEqualsToModel(layersArray[1], SAMPLE_LAYER2);
+      await assertEqualsToModel(layersArray[2], SAMPLE_LAYER4);
+      await assertEqualsToModel(layersArray[3], SAMPLE_LAYER1);
     });
   });
 
   describe("layers removed", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       diff = {
         layersAdded: [],
         layersChanged: [],
@@ -111,6 +115,7 @@ describe("applyContextDiffToMap", () => {
         layersReordered: [],
       };
       applyContextDiffToMap(map, diff);
+      await getMapUpdatesPromise(map);
     });
     it("deletes the layers", () => {
       expect(map.getLayers().getLength()).toEqual(0);
@@ -118,7 +123,7 @@ describe("applyContextDiffToMap", () => {
   });
 
   describe("layers changed", () => {
-    beforeEach(() => {
+    beforeEach(async () => {
       diff = {
         layersAdded: [],
         layersChanged: [
@@ -146,18 +151,19 @@ describe("applyContextDiffToMap", () => {
         layersReordered: [],
       };
       applyContextDiffToMap(map, diff);
+      await getMapUpdatesPromise(map);
       layersArray = map.getLayers().getArray();
     });
-    it("modifies the layers accordingly", () => {
+    it("modifies the layers accordingly", async () => {
       expect(layersArray.length).toEqual(2);
-      assertEqualsToModel(layersArray[0], diff.layersChanged[0].layer);
-      assertEqualsToModel(layersArray[1], diff.layersChanged[1].layer);
+      await assertEqualsToModel(layersArray[0], diff.layersChanged[0].layer);
+      await assertEqualsToModel(layersArray[1], diff.layersChanged[1].layer);
     });
 
     describe("layers changed (updatable properties only)", () => {
       let prevOlLayer: BaseLayer;
       let newOlLayer: BaseLayer;
-      beforeEach(() => {
+      beforeEach(async () => {
         diff = {
           layersAdded: [],
           layersChanged: [
@@ -175,6 +181,7 @@ describe("applyContextDiffToMap", () => {
         };
         prevOlLayer = map.getLayers().item(1);
         applyContextDiffToMap(map, diff);
+        await getMapUpdatesPromise(map);
         newOlLayer = map.getLayers().item(1);
       });
       it("modifies the layer without recreating it", () => {
@@ -194,7 +201,7 @@ describe("applyContextDiffToMap", () => {
           ...SAMPLE_CONTEXT,
           layers: [SAMPLE_LAYER1, SAMPLE_LAYER2, SAMPLE_LAYER3],
         };
-        map = await createMapFromContext(context);
+        map = createMapFromContext(context);
         diff = {
           layersAdded: [],
           layersChanged: [],
@@ -213,13 +220,14 @@ describe("applyContextDiffToMap", () => {
           ],
         };
         applyContextDiffToMap(map, diff);
+        await getMapUpdatesPromise(map);
         layersArray = map.getLayers().getArray();
       });
-      it("moves the layers accordingly", () => {
+      it("moves the layers accordingly", async () => {
         expect(layersArray.length).toEqual(3);
-        assertEqualsToModel(layersArray[0], SAMPLE_LAYER2);
-        assertEqualsToModel(layersArray[1], SAMPLE_LAYER1);
-        assertEqualsToModel(layersArray[2], SAMPLE_LAYER3);
+        await assertEqualsToModel(layersArray[0], SAMPLE_LAYER2);
+        await assertEqualsToModel(layersArray[1], SAMPLE_LAYER1);
+        await assertEqualsToModel(layersArray[2], SAMPLE_LAYER3);
       });
     });
 
@@ -229,7 +237,7 @@ describe("applyContextDiffToMap", () => {
           ...SAMPLE_CONTEXT,
           layers: [SAMPLE_LAYER1, SAMPLE_LAYER3, SAMPLE_LAYER4, SAMPLE_LAYER2],
         };
-        map = await createMapFromContext(context);
+        map = createMapFromContext(context);
         diff = {
           layersAdded: [],
           layersChanged: [],
@@ -248,14 +256,15 @@ describe("applyContextDiffToMap", () => {
           ],
         };
         applyContextDiffToMap(map, diff);
+        await getMapUpdatesPromise(map);
         layersArray = map.getLayers().getArray();
       });
-      it("moves the layers accordingly", () => {
+      it("moves the layers accordingly", async () => {
         expect(layersArray.length).toEqual(4);
-        assertEqualsToModel(layersArray[0], SAMPLE_LAYER4);
-        assertEqualsToModel(layersArray[1], SAMPLE_LAYER3);
-        assertEqualsToModel(layersArray[2], SAMPLE_LAYER1);
-        assertEqualsToModel(layersArray[3], SAMPLE_LAYER2);
+        await assertEqualsToModel(layersArray[0], SAMPLE_LAYER4);
+        await assertEqualsToModel(layersArray[1], SAMPLE_LAYER3);
+        await assertEqualsToModel(layersArray[2], SAMPLE_LAYER1);
+        await assertEqualsToModel(layersArray[3], SAMPLE_LAYER2);
       });
     });
   });
@@ -263,7 +272,7 @@ describe("applyContextDiffToMap", () => {
   describe("view change", () => {
     describe("set to default view", () => {
       beforeEach(async () => {
-        map = await createMapFromContext(SAMPLE_CONTEXT);
+        map = createMapFromContext(SAMPLE_CONTEXT);
         diff = {
           layersAdded: [],
           layersChanged: [],
@@ -272,6 +281,7 @@ describe("applyContextDiffToMap", () => {
           viewChanges: null,
         };
         applyContextDiffToMap(map, diff);
+        await getMapUpdatesPromise(map);
       });
       it("set the view back to default", () => {
         const view = map.getView();
@@ -282,7 +292,7 @@ describe("applyContextDiffToMap", () => {
 
     describe("set to view with extent", () => {
       beforeEach(async () => {
-        map = await createMapFromContext(SAMPLE_CONTEXT);
+        map = createMapFromContext(SAMPLE_CONTEXT);
         diff = {
           layersAdded: [],
           layersChanged: [],
@@ -293,6 +303,7 @@ describe("applyContextDiffToMap", () => {
           },
         };
         applyContextDiffToMap(map, diff);
+        await getMapUpdatesPromise(map);
       });
       it("set the view to the given extent, transformed to the view projection", () => {
         const view = map.getView();
@@ -305,7 +316,7 @@ describe("applyContextDiffToMap", () => {
 
     describe("set to view with geometry", () => {
       beforeEach(async () => {
-        map = await createMapFromContext(SAMPLE_CONTEXT);
+        map = createMapFromContext(SAMPLE_CONTEXT);
         diff = {
           layersAdded: [],
           layersChanged: [],
@@ -323,6 +334,7 @@ describe("applyContextDiffToMap", () => {
           },
         };
         applyContextDiffToMap(map, diff);
+        await getMapUpdatesPromise(map);
       });
       it("set the view to the given extent, transformed to the view projection", () => {
         const view = map.getView();
@@ -342,7 +354,7 @@ describe("applyContextDiffToMap", () => {
         ...context,
         layers: [SAMPLE_LAYER1, SAMPLE_LAYER5, SAMPLE_LAYER3, SAMPLE_LAYER4],
       };
-      map = await createMapFromContext(context);
+      map = createMapFromContext(context);
       diff = {
         layersAdded: [
           {
@@ -381,13 +393,75 @@ describe("applyContextDiffToMap", () => {
         ],
       };
       applyContextDiffToMap(map, diff);
+      await getMapUpdatesPromise(map);
       layersArray = map.getLayers().getArray();
     });
-    it("applies all changes", () => {
+    it("applies all changes", async () => {
       expect(layersArray.length).toEqual(3);
-      assertEqualsToModel(layersArray[0], SAMPLE_LAYER2);
-      assertEqualsToModel(layersArray[1], changedLayer);
-      assertEqualsToModel(layersArray[2], SAMPLE_LAYER5);
+      await assertEqualsToModel(layersArray[0], SAMPLE_LAYER2);
+      await assertEqualsToModel(layersArray[1], changedLayer);
+      await assertEqualsToModel(layersArray[2], SAMPLE_LAYER5);
+    });
+  });
+
+  describe("combined changes (2)", () => {
+    beforeEach(async () => {
+      context = {
+        ...context,
+        layers: [SAMPLE_LAYER1, SAMPLE_LAYER5, SAMPLE_LAYER3, SAMPLE_LAYER4],
+      };
+      const newContext = {
+        ...context,
+        layers: [SAMPLE_LAYER3, SAMPLE_LAYER1],
+      };
+      map = createMapFromContext(context);
+      applyContextDiffToMap(map, computeMapContextDiff(newContext, context));
+      await getMapUpdatesPromise(map);
+      layersArray = map.getLayers().getArray();
+    });
+    it("applies all changes", async () => {
+      expect(layersArray.length).toEqual(2);
+      await assertEqualsToModel(layersArray[0], SAMPLE_LAYER3);
+      await assertEqualsToModel(layersArray[1], SAMPLE_LAYER1);
+    });
+  });
+
+  describe("multiple sequential changes", () => {
+    beforeEach(() => {
+      context = {
+        ...SAMPLE_CONTEXT,
+        layers: [SAMPLE_LAYER1, SAMPLE_LAYER2, SAMPLE_LAYER3],
+      };
+      map = createMapFromContext(context);
+    });
+
+    it("applies three successive diffs in order without awaiting between them", async () => {
+      // Diff 1: remove LAYER1, add LAYER4 at end
+      const context1: MapContext = {
+        ...SAMPLE_CONTEXT,
+        layers: [SAMPLE_LAYER2, SAMPLE_LAYER3, SAMPLE_LAYER4],
+      };
+      // Diff 2: add LAYER5 at position 0
+      const context2: MapContext = {
+        ...SAMPLE_CONTEXT,
+        layers: [SAMPLE_LAYER5, SAMPLE_LAYER2, SAMPLE_LAYER3, SAMPLE_LAYER4],
+      };
+      // Diff 3: reorder LAYER4 to front, remove LAYER3
+      const context3: MapContext = {
+        ...SAMPLE_CONTEXT,
+        layers: [SAMPLE_LAYER4, SAMPLE_LAYER5, SAMPLE_LAYER2],
+      };
+
+      applyContextDiffToMap(map, computeMapContextDiff(context1, context));
+      applyContextDiffToMap(map, computeMapContextDiff(context2, context1));
+      applyContextDiffToMap(map, computeMapContextDiff(context3, context2));
+      await getMapUpdatesPromise(map);
+
+      layersArray = map.getLayers().getArray();
+      expect(layersArray.length).toEqual(3);
+      await assertEqualsToModel(layersArray[0], SAMPLE_LAYER4);
+      await assertEqualsToModel(layersArray[1], SAMPLE_LAYER5);
+      await assertEqualsToModel(layersArray[2], SAMPLE_LAYER2);
     });
   });
 });

--- a/packages/openlayers/lib/map/apply-context-diff.ts
+++ b/packages/openlayers/lib/map/apply-context-diff.ts
@@ -1,122 +1,131 @@
 import Map from "ol/Map.js";
 import { MapContextDiff } from "@geospatial-sdk/core";
-import { createLayer, createView, updateLayerInMap } from "./create-map.js";
+import { createView, updateLayerInMap } from "./create-map.js";
 import { fromLonLat, transformExtent } from "ol/proj.js";
 import GeoJSON from "ol/format/GeoJSON.js";
 import SimpleGeometry from "ol/geom/SimpleGeometry.js";
 import { propagateLayerStateChangeEventToMap } from "./register-events.js";
+import { createLayer } from "./layer-creation.js";
+import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
 
 const GEOJSON = new GeoJSON();
 
 /**
- * Apply a context diff to an OpenLayers map
+ * Apply a context diff to an OpenLayers map.
+ * The function returns synchronously; all asynchronous modifications are stacked
+ * in a promise chain stored on the map.
  * @param map
  * @param contextDiff
  */
-export async function applyContextDiffToMap(
+export function applyContextDiffToMap(
   map: Map,
   contextDiff: MapContextDiff,
-): Promise<Map> {
-  const layers = map.getLayers();
+): Map {
+  const existingChain: Promise<void> =
+    map.get(`${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`) ??
+    Promise.resolve();
 
-  // removed layers (sorted by descending position)
-  if (contextDiff.layersRemoved.length > 0) {
-    const removed = contextDiff.layersRemoved.sort(
-      (a, b) => b.position - a.position,
-    );
-    for (const layerRemoved of removed) {
-      layers.item(layerRemoved.position).dispose();
-      layers.removeAt(layerRemoved.position);
+  const newChain = existingChain.then(async () => {
+    const layers = map.getLayers();
+
+    // removed layers (sorted by descending position)
+    if (contextDiff.layersRemoved.length > 0) {
+      const removed = contextDiff.layersRemoved.sort(
+        (a, b) => b.position - a.position,
+      );
+      for (const layerRemoved of removed) {
+        layers.item(layerRemoved.position).dispose();
+        layers.removeAt(layerRemoved.position);
+      }
     }
-  }
 
-  // insert added layers
-  const newLayers = await Promise.all(
-    contextDiff.layersAdded.map((layerAdded) => createLayer(layerAdded.layer)),
-  );
-
-  newLayers.forEach((layer, index) => {
-    if (!layer) {
-      return;
-    }
-    const position = contextDiff.layersAdded[index].position;
-    if (position >= layers.getLength()) {
-      layers.push(layer);
-    } else {
-      layers.insertAt(position, layer);
-    }
-    propagateLayerStateChangeEventToMap(map, layer);
-  });
-
-  // move reordered layers (sorted by ascending new position)
-  if (contextDiff.layersReordered.length > 0) {
-    const reordered = contextDiff.layersReordered.sort(
-      (a, b) => a.newPosition - b.newPosition,
-    );
-    const olLayers = reordered.map((layer) =>
-      layers.item(layer.previousPosition),
-    );
-    const layersArray = layers.getArray();
-    for (let i = 0; i < reordered.length; i++) {
-      layersArray[reordered[i].newPosition] = olLayers[i];
-    }
-    map.setLayers([...layersArray]);
-  }
-
-  // update or recreate changed layers
-  const updatePromises = [];
-  for (const layerChanged of contextDiff.layersChanged) {
-    updatePromises.push(
-      updateLayerInMap(
-        map,
-        layerChanged.layer,
-        layerChanged.position,
-        layerChanged.previousLayer,
+    // insert added layers
+    const newLayers = await Promise.all(
+      contextDiff.layersAdded.map((layerAdded) =>
+        createLayer(layerAdded.layer),
       ),
     );
-  }
 
-  if (typeof contextDiff.viewChanges !== "undefined") {
-    const { viewChanges } = contextDiff;
-    const view = map.getView();
-    const projection = view.getProjection();
-    if (viewChanges === null) {
-      map.setView(createView(viewChanges, map));
-      return map;
-    }
-    if (viewChanges.maxZoom) {
-      view.setMaxZoom(viewChanges.maxZoom);
-    }
-    if ("geometry" in viewChanges) {
-      const geom = GEOJSON.readGeometry(viewChanges.geometry, {
-        dataProjection: "EPSG:4326",
-        featureProjection: projection,
-      });
-      view.fit(geom as SimpleGeometry, {
-        size: map.getSize(),
-      });
-    } else if ("extent" in viewChanges) {
-      view.fit(transformExtent(viewChanges.extent, "EPSG:4326", projection), {
-        size: map.getSize(),
-      });
-    } else {
-      const { center: centerInViewProj, zoom } = viewChanges;
-      const center = centerInViewProj
-        ? fromLonLat(centerInViewProj, projection)
-        : [0, 0];
-      view.setCenter(center);
-      view.setZoom(zoom);
-      // TODO: factorize this better
-      // if (viewChanges.maxExtent) {
-      //   map.setView(new View({
-      //
-      //   }))
-      // }
-    }
-  }
+    newLayers.forEach((layer, index) => {
+      if (!layer) {
+        return;
+      }
+      const position = contextDiff.layersAdded[index].position;
+      if (position >= layers.getLength()) {
+        layers.push(layer);
+      } else {
+        layers.insertAt(position, layer);
+      }
+      propagateLayerStateChangeEventToMap(map, layer);
+    });
 
-  // wait for all layers to have been updated
-  await Promise.all(updatePromises);
+    // move reordered layers (sorted by ascending new position)
+    if (contextDiff.layersReordered.length > 0) {
+      const reordered = contextDiff.layersReordered.sort(
+        (a, b) => a.newPosition - b.newPosition,
+      );
+      const olLayers = reordered.map((layer) =>
+        layers.item(layer.previousPosition),
+      );
+      const layersArray = layers.getArray();
+      for (let i = 0; i < reordered.length; i++) {
+        layersArray[reordered[i].newPosition] = olLayers[i];
+      }
+      map.setLayers([...layersArray]);
+    }
+
+    // update or recreate changed layers
+    await Promise.all(
+      contextDiff.layersChanged.map((layerChanged) =>
+        updateLayerInMap(
+          map,
+          layerChanged.layer,
+          layerChanged.position,
+          layerChanged.previousLayer,
+        ),
+      ),
+    );
+
+    if (typeof contextDiff.viewChanges !== "undefined") {
+      const { viewChanges } = contextDiff;
+      const view = map.getView();
+      const projection = view.getProjection();
+      if (viewChanges === null) {
+        map.setView(createView(viewChanges, map));
+        return map;
+      }
+      if (viewChanges.maxZoom) {
+        view.setMaxZoom(viewChanges.maxZoom);
+      }
+      if ("geometry" in viewChanges) {
+        const geom = GEOJSON.readGeometry(viewChanges.geometry, {
+          dataProjection: "EPSG:4326",
+          featureProjection: projection,
+        });
+        view.fit(geom as SimpleGeometry, {
+          size: map.getSize(),
+        });
+      } else if ("extent" in viewChanges) {
+        view.fit(transformExtent(viewChanges.extent, "EPSG:4326", projection), {
+          size: map.getSize(),
+        });
+      } else {
+        const { center: centerInViewProj, zoom } = viewChanges;
+        const center = centerInViewProj
+          ? fromLonLat(centerInViewProj, projection)
+          : [0, 0];
+        view.setCenter(center);
+        view.setZoom(zoom);
+        // TODO: factorize this better
+        // if (viewChanges.maxExtent) {
+        //   map.setView(new View({
+        //
+        //   }))
+        // }
+      }
+    }
+  });
+  map.set(`${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`, newChain);
 
   return map;
 }

--- a/packages/openlayers/lib/map/apply-context-diff.ts
+++ b/packages/openlayers/lib/map/apply-context-diff.ts
@@ -1,6 +1,10 @@
 import Map from "ol/Map.js";
 import { MapContextDiff } from "@geospatial-sdk/core";
-import { createView, getMapUpdatesPromise, updateLayerInMap } from "./create-map.js";
+import {
+  createView,
+  getMapUpdatesPromise,
+  updateLayerInMap,
+} from "./create-map.js";
 import { fromLonLat, transformExtent } from "ol/proj.js";
 import GeoJSON from "ol/format/GeoJSON.js";
 import SimpleGeometry from "ol/geom/SimpleGeometry.js";

--- a/packages/openlayers/lib/map/apply-context-diff.ts
+++ b/packages/openlayers/lib/map/apply-context-diff.ts
@@ -1,6 +1,6 @@
 import Map from "ol/Map.js";
 import { MapContextDiff } from "@geospatial-sdk/core";
-import { createView, updateLayerInMap } from "./create-map.js";
+import { createView, getMapUpdatesPromise, updateLayerInMap } from "./create-map.js";
 import { fromLonLat, transformExtent } from "ol/proj.js";
 import GeoJSON from "ol/format/GeoJSON.js";
 import SimpleGeometry from "ol/geom/SimpleGeometry.js";
@@ -21,11 +21,7 @@ export function applyContextDiffToMap(
   map: Map,
   contextDiff: MapContextDiff,
 ): Map {
-  const existingChain: Promise<void> =
-    map.get(`${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`) ??
-    Promise.resolve();
-
-  const newChain = existingChain.then(async () => {
+  const newChain = getMapUpdatesPromise(map).then(async () => {
     const layers = map.getLayers();
 
     // removed layers (sorted by descending position)

--- a/packages/openlayers/lib/map/create-map.test.ts
+++ b/packages/openlayers/lib/map/create-map.test.ts
@@ -1,54 +1,20 @@
-import {
-  MapContext,
-  MapContextLayer,
-  MapContextLayerGeojson,
-  MapContextLayerWms,
-} from "@geospatial-sdk/core";
+import { MapContext } from "@geospatial-sdk/core";
 import {
   MAP_CTX_EXTENT_FIXTURE,
   MAP_CTX_FIXTURE,
   MAP_CTX_LAYER_GEOJSON_FIXTURE,
-  MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE,
-  MAP_CTX_LAYER_GEOTIFF_FIXTURE,
-  MAP_CTX_LAYER_MAPBLIBRE_STYLE_FIXTURE,
-  MAP_CTX_LAYER_MVT_FIXTURE,
-  MAP_CTX_LAYER_OGCAPI_FIXTURE,
-  MAP_CTX_LAYER_WFS_FIXTURE,
   MAP_CTX_LAYER_WMS_FIXTURE,
-  MAP_CTX_LAYER_WMTS_FIXTURE,
   MAP_CTX_LAYER_XYZ_FIXTURE,
 } from "@geospatial-sdk/core/fixtures/map-context.fixtures.js";
-import { FeatureCollection } from "geojson";
-import { MapboxVectorLayer } from "ol-mapbox-style";
-import { FeatureUrlFunction } from "ol/featureloader.js";
-import GeoJSON from "ol/format/GeoJSON.js";
-import ImageTile from "ol/ImageTile.js";
-import Layer from "ol/layer/Layer.js";
-import TileLayer from "ol/layer/Tile.js";
-import VectorLayer from "ol/layer/Vector.js";
-import VectorTileLayer from "ol/layer/VectorTile.js";
-import WebGLTileLayer from "ol/layer/WebGLTile.js";
 import Map from "ol/Map.js";
-import { VectorTile } from "ol/source.js";
-import GeoTIFF from "ol/source/GeoTIFF.js";
-import TileWMS from "ol/source/TileWMS.js";
-import VectorSource from "ol/source/Vector.js";
-import WMTS from "ol/source/WMTS.js";
-import XYZ from "ol/source/XYZ.js";
-import TileState from "ol/TileState.js";
 import View from "ol/View.js";
 import { beforeEach } from "vitest";
 import {
-  createLayer,
   createMapFromContext,
   createView,
+  getMapUpdatesPromise,
   resetMapFromContext,
 } from "./create-map.js";
-import { tileLoadErrorCatchFunction } from "./handle-errors.js";
-import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
-import ImageLayer from "ol/layer/Image.js";
-import ImageWMS from "ol/source/ImageWMS.js";
-import { OgcApiEndpoint } from "@camptocamp/ogc-client";
 
 vi.mock("./handle-errors", async (importOriginal) => {
   const actual =
@@ -65,737 +31,90 @@ beforeEach(() => {
   vi.clearAllMocks();
 });
 
-describe("MapContextService", () => {
-  describe("#createLayer", () => {
-    let layerModel: MapContextLayer, layer: Layer;
-    const eventCallback = vi.fn();
-
-    describe("XYZ", () => {
-      beforeEach(async () => {
-        layerModel = MAP_CTX_LAYER_XYZ_FIXTURE;
-        layer = await createLayer(layerModel);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-      });
-      it("create a tile layer", () => {
-        expect(layer).toBeTruthy();
-        expect(layer).toBeInstanceOf(TileLayer);
-      });
-      it("set correct layer properties", () => {
-        expect(layer.getVisible()).toBe(true);
-        expect(layer.getOpacity()).toBe(1);
-        expect(layer.get("label")).toBeUndefined();
-        expect(layer.getSource()?.getAttributions()).toBeNull();
-      });
-      it("create a XYZ source", () => {
-        const source = layer.getSource();
-        expect(source).toBeInstanceOf(XYZ);
-      });
-      it("set correct urls", () => {
-        const source = layer.getSource() as XYZ;
-        const urls = source.getUrls() ?? [];
-        expect(urls.length).toBe(3);
-        expect(urls[0]).toEqual(
-          "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
-        );
-      });
-      it("should set tileLoadErrorCatchFunction to handle errors", () => {
-        const source = layer.getSource() as XYZ;
-        const tileLoadFunction = source.getTileLoadFunction();
-        expect(tileLoadFunction).toBeInstanceOf(Function);
-        const tile = new ImageTile(
-          [0, 0, 0],
-          TileState.IDLE,
-          "",
-          null,
-          () => {},
-        );
-        tileLoadFunction(tile, "http://example.com/tile");
-        expect(tileLoadErrorCatchFunction).toHaveBeenCalled();
-      });
-      it("should configure XYZ source with referrerPolicy from layer model", async () => {
-        const layerWithPolicy = await createLayer({
-          ...MAP_CTX_LAYER_XYZ_FIXTURE,
-          referrerPolicy: "strict-origin-when-cross-origin",
-        });
-        const source = layerWithPolicy.getSource() as XYZ;
-        // referrerPolicy is protected on TileImage; access via bracket to verify it is set
-        expect(
-          (source as unknown as Record<string, unknown>)["referrerPolicy"],
-        ).toBe("strict-origin-when-cross-origin");
-      });
-      it("emits a loaded event initially", async () => {
-        await vi.runAllTimersAsync();
-        expect(eventCallback).toHaveBeenCalledWith({
-          layerState: {
-            loaded: true,
-          },
-          target: layer,
-          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-        });
-      });
+describe("createView", () => {
+  let view: View;
+  let map: Map;
+  describe("from center and zoom", () => {
+    const contextModel = MAP_CTX_FIXTURE;
+    beforeEach(async () => {
+      map = createMapFromContext(contextModel);
+      await getMapUpdatesPromise(map);
+      view = createView(contextModel.view, map);
     });
-    describe("OGCAPI (as geojson items)", () => {
-      beforeEach(async () => {
-        layerModel = MAP_CTX_LAYER_OGCAPI_FIXTURE;
-        layer = await createLayer(layerModel);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-      });
-      it("create a vector layer", () => {
-        expect(layer).toBeTruthy();
-        expect(layer).toBeInstanceOf(VectorLayer);
-      });
-      it("set correct layer properties", () => {
-        expect(layer.getVisible()).toBe(true);
-        expect(layer.getOpacity()).toBe(1);
-        expect(layer.get("label")).toBeUndefined();
-        expect(layer.getSource()?.getAttributions()).toBeNull();
-      });
-      it("create a vector source", () => {
-        const source = layer.getSource();
-        expect(source).toBeInstanceOf(VectorSource);
-      });
-      it("set correct url", () => {
-        const source = layer.getSource() as VectorSource;
-        const url = source.getUrl();
-        expect(url).toBe(
-          "https://demo.ldproxy.net/zoomstack/collections/airports/items?f=json",
-        );
-      });
-      it("emits a loaded event initially", async () => {
-        await vi.runAllTimersAsync();
-        expect(eventCallback).toHaveBeenCalledWith({
-          layerState: {
-            loaded: true,
-          },
-          target: layer,
-          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-        });
-      });
+    it("create a view", () => {
+      expect(view).toBeTruthy();
+      expect(view).toBeInstanceOf(View);
     });
-    describe("OGCAPI (with failing endpoint)", () => {
-      beforeEach(async () => {
-        vi.spyOn(
-          OgcApiEndpoint.prototype,
-          "getCollectionItemsUrl",
-        ).mockRejectedValue(new Error("Failed to load collection"));
-        layerModel = MAP_CTX_LAYER_OGCAPI_FIXTURE;
-        layer = await createLayer(layerModel);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-error`, eventCallback);
-      });
-
-      afterEach(() => {
-        vi.restoreAllMocks();
-      });
-
-      it("creates an empty vector layer", () => {
-        expect(layer).toBeInstanceOf(VectorLayer);
-        expect(layer.getSource()).toBeNull();
-      });
-
-      it("emits a loading error event", async () => {
-        await vi.runAllTimersAsync();
-        expect(eventCallback).toHaveBeenCalledWith(
-          expect.objectContaining({
-            type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
-            error: expect.any(Error),
-            target: layer,
-          }),
-        );
-      });
+    it("set center", () => {
+      const center = view.getCenter();
+      expect(center).toEqual([862726.0536478702, 6207260.308175252]);
     });
-    describe("WMS", () => {
-      beforeEach(async () => {
-        layerModel = MAP_CTX_LAYER_WMS_FIXTURE;
-        layer = await createLayer(layerModel);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-      });
-      it("create a tile layer", () => {
-        expect(layer).toBeTruthy();
-        expect(layer).toBeInstanceOf(TileLayer);
-      });
-      it("set correct layer properties", () => {
-        expect(layer.getVisible()).toBe(false);
-        expect(layer.getOpacity()).toBe(0.5);
-        expect(layer.get("label")).toBe("Communes");
-        // @ts-expect-error TS2554 we're not providing a view extent here
-        expect(layer.getSource()?.getAttributions()!()).toEqual(["camptocamp"]);
-      });
-      it("create a TileWMS source", () => {
-        const source = layer.getSource();
-        expect(source).toBeInstanceOf(TileWMS);
-      });
-      it("set correct WMS params", () => {
-        const source = layer.getSource() as TileWMS;
-        const params = source.getParams();
-        expect(params).toEqual({
-          LAYERS: (layerModel as MapContextLayerWms).name,
-          STYLES: (layerModel as MapContextLayerWms).style,
-          TILED: true,
-        });
-      });
-      it("sets custom WMS FORMAT param when provided", async () => {
-        layerModel = { ...MAP_CTX_LAYER_WMS_FIXTURE, format: "image/jpeg" };
-        layer = await createLayer(layerModel);
-        const source = layer.getSource() as TileWMS;
-        const params = source.getParams();
-        expect(params).toEqual({
-          LAYERS: (layerModel as MapContextLayerWms).name,
-          FORMAT: "image/jpeg",
-          STYLES: (layerModel as MapContextLayerWms).style,
-          TILED: true,
-        });
-      });
-      it("sets WMS dimension params with uppercased keys and ISO Date values", async () => {
-        layerModel = {
-          ...MAP_CTX_LAYER_WMS_FIXTURE,
-          dimensionValues: {
-            time: new Date("2020-01-01T00:00:00.000Z"),
-            elevation: 500,
-          },
-        };
-        layer = await createLayer(layerModel);
-        const source = layer.getSource() as TileWMS;
-        const params = source.getParams();
-        expect(params).toEqual({
-          LAYERS: (layerModel as MapContextLayerWms).name,
-          STYLES: (layerModel as MapContextLayerWms).style,
-          TILED: true,
-          TIME: "2020-01-01T00:00:00.000Z",
-          ELEVATION: 500,
-        });
-      });
-      it("set correct url without existing REQUEST and SERVICE params", () => {
-        const source = layer.getSource() as TileWMS;
-        const urls = source.getUrls() || [];
-        expect(urls.length).toBe(1);
-        expect(urls[0]).toBe(
-          "https://www.datagrandest.fr/geoserver/region-grand-est/ows",
-        );
-      });
-      it("set WMS gutter of 20px", () => {
-        const source = layer.getSource() as TileWMS;
-        const gutter = source["gutter_"];
-        expect(gutter).toBe(20);
-      });
-      it("should set tileLoadErrorCatchFunction to handle errors", () => {
-        const source = layer.getSource() as TileWMS;
-        const tileLoadFunction = source.getTileLoadFunction();
-        expect(tileLoadFunction).toBeInstanceOf(Function);
-        const tile = new ImageTile(
-          [0, 0, 0],
-          TileState.IDLE,
-          "",
-          null,
-          () => {},
-        );
-        tileLoadFunction(tile, "http://example.com/tile");
-        expect(tileLoadErrorCatchFunction).toHaveBeenCalled();
-      });
-
-      it("emits a loaded event initially", async () => {
-        await vi.runAllTimersAsync();
-        expect(eventCallback).toHaveBeenCalledWith({
-          layerState: {
-            loaded: true,
-          },
-          target: layer,
-          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-        });
-      });
-
-      describe("not using tiles", () => {
-        beforeEach(async () => {
-          layerModel = { ...MAP_CTX_LAYER_WMS_FIXTURE, useTiles: false };
-          layer = await createLayer(layerModel);
-          layer.on(
-            `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-            eventCallback,
-          );
-          layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-        });
-        it("create an image layer", () => {
-          expect(layer).toBeTruthy();
-          expect(layer).toBeInstanceOf(ImageLayer);
-        });
-        it("set correct layer properties", () => {
-          expect(layer.getVisible()).toBe(false);
-          expect(layer.getOpacity()).toBe(0.5);
-          expect(layer.get("label")).toBe("Communes");
-          // @ts-expect-error TS2554 we're not providing a view extent here
-          expect(layer.getSource()?.getAttributions()!()).toEqual([
-            "camptocamp",
-          ]);
-        });
-        it("create an ImageWMS source", () => {
-          const source = layer.getSource();
-          expect(source).toBeInstanceOf(ImageWMS);
-        });
-        it("set correct WMS params", () => {
-          const source = layer.getSource() as ImageWMS;
-          const params = source.getParams();
-          expect(params).toEqual({
-            LAYERS: (layerModel as MapContextLayerWms).name,
-            STYLES: (layerModel as MapContextLayerWms).style,
-          });
-        });
-        it("sets custom WMS FORMAT param when provided", async () => {
-          layerModel = {
-            ...MAP_CTX_LAYER_WMS_FIXTURE,
-            useTiles: false,
-            format: "image/jpeg",
-          };
-          layer = await createLayer(layerModel);
-          const source = layer.getSource() as ImageWMS;
-          const params = source.getParams();
-          expect(params).toEqual({
-            LAYERS: (layerModel as MapContextLayerWms).name,
-            FORMAT: "image/jpeg",
-            STYLES: (layerModel as MapContextLayerWms).style,
-          });
-        });
-        it("sets WMS dimension params with uppercased keys and ISO Date values", async () => {
-          layerModel = {
-            ...MAP_CTX_LAYER_WMS_FIXTURE,
-            useTiles: false,
-            dimensionValues: {
-              time: new Date("2020-01-01T00:00:00.000Z"),
-              elevation: 500,
-            },
-          };
-          layer = await createLayer(layerModel);
-          const source = layer.getSource() as ImageWMS;
-          const params = source.getParams();
-          expect(params).toEqual({
-            LAYERS: (layerModel as MapContextLayerWms).name,
-            STYLES: (layerModel as MapContextLayerWms).style,
-            TIME: "2020-01-01T00:00:00.000Z",
-            ELEVATION: 500,
-          });
-        });
-        it("set correct url without existing REQUEST and SERVICE params", () => {
-          const source = layer.getSource() as ImageWMS;
-          const url = source.getUrl();
-          expect(url).toBe(
-            "https://www.datagrandest.fr/geoserver/region-grand-est/ows",
-          );
-        });
-      });
-    });
-
-    describe("WFS", () => {
-      beforeEach(async () => {
-        layerModel = MAP_CTX_LAYER_WFS_FIXTURE;
-        layer = await createLayer(layerModel);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-      });
-      it("create a vector layer", () => {
-        expect(layer).toBeTruthy();
-        expect(layer).toBeInstanceOf(VectorLayer);
-      });
-      it("set correct layer properties", () => {
-        expect(layer.getVisible()).toBe(true);
-        expect(layer.getOpacity()).toBe(0.5);
-        expect(layer.get("label")).toBe("Communes");
-        const source = layer.getSource();
-        expect(source).toBeInstanceOf(VectorSource);
-
-        const attributions = layer.getSource()?.getAttributions();
-        expect(attributions).not.toBeNull();
-        // @ts-expect-error TS2554 we're not providing a view extent here
-        expect(attributions!()).toEqual(["camptocamp"]);
-      });
-      it("create a Vector source", () => {
-        const source = layer.getSource();
-        expect(source).toBeInstanceOf(VectorSource);
-      });
-      it("set correct url load function", () => {
-        const source = layer.getSource() as VectorSource;
-        const urlLoader = source.getUrl() as FeatureUrlFunction;
-        // @ts-expect-error TS2345
-        expect(urlLoader([10, 20, 30, 40])).toBe(
-          "https://www.datagrandest.fr/geoserver/region-grand-est/ows?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application%2Fjson&typename=ms%3Acommune_actuelle_3857&srsname=EPSG%3A3857&bbox=10%2C20%2C30%2C40%2CEPSG%3A3857&maxFeatures=10000",
-        );
-      });
-      it("emits a loaded event initially", async () => {
-        await vi.runAllTimersAsync();
-        expect(eventCallback).toHaveBeenCalledWith({
-          layerState: {
-            loaded: true,
-          },
-          target: layer,
-          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-        });
-      });
-    });
-
-    describe("GEOJSON", () => {
-      describe("with inline data", () => {
-        beforeEach(async () => {
-          layerModel = MAP_CTX_LAYER_GEOJSON_FIXTURE;
-          layer = await createLayer(layerModel);
-          layer.on(
-            `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-            eventCallback,
-          );
-          layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-        });
-        it("create a VectorLayer", () => {
-          expect(layer).toBeTruthy();
-          expect(layer).toBeInstanceOf(VectorLayer);
-        });
-        it("set correct layer properties", () => {
-          expect(layer.getVisible()).toBe(true);
-          expect(layer.getOpacity()).toBe(0.8);
-          expect(layer.get("label")).toBe("Regions");
-        });
-        it("create a VectorSource source", () => {
-          const source = layer.getSource();
-          expect(source).toBeInstanceOf(VectorSource);
-        });
-        it("add features", () => {
-          const source = layer.getSource() as VectorSource;
-          const features = source.getFeatures();
-          const data = (layerModel as MapContextLayerGeojson)
-            .data as FeatureCollection;
-          expect(features.length).toBe(data.features.length);
-        });
-        it("emits a loaded event", async () => {
-          await vi.runAllTimersAsync();
-          expect(eventCallback).toHaveBeenCalledWith({
-            layerState: {
-              loaded: true,
-            },
-            target: layer,
-            type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-          });
-        });
-      });
-      describe("with inline data as string", () => {
-        beforeEach(async () => {
-          layerModel = { ...MAP_CTX_LAYER_GEOJSON_FIXTURE };
-          layerModel.data = JSON.stringify(layerModel.data);
-          layer = await createLayer(layerModel);
-        });
-        it("create a VectorLayer", () => {
-          expect(layer).toBeTruthy();
-          expect(layer).toBeInstanceOf(VectorLayer);
-        });
-        it("create a VectorSource source", () => {
-          const source = layer.getSource();
-          expect(source).toBeInstanceOf(VectorSource);
-        });
-        it("add features", () => {
-          const source = layer.getSource() as VectorSource;
-          const features = source.getFeatures();
-          expect(features.length).toBe(
-            (MAP_CTX_LAYER_GEOJSON_FIXTURE.data as FeatureCollection).features
-              .length,
-          );
-        });
-      });
-      describe("with invalid inline data as string", () => {
-        beforeEach(async () => {
-          const spy = vi.spyOn(window.console, "warn");
-          spy.mockClear();
-          layerModel = {
-            ...MAP_CTX_LAYER_GEOJSON_FIXTURE,
-            url: undefined,
-            data: "blargz",
-          };
-          layer = await createLayer(layerModel);
-          layer.on(
-            `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
-            eventCallback,
-          );
-        });
-        it("create a VectorLayer", () => {
-          expect(layer).toBeTruthy();
-          expect(layer).toBeInstanceOf(VectorLayer);
-        });
-        it("outputs error in the console", () => {
-          expect(window.console.warn).toHaveBeenCalled();
-        });
-        it("create an empty VectorSource source", () => {
-          const source = layer.getSource() as VectorSource;
-          expect(source).toBeInstanceOf(VectorSource);
-          expect(source.getFeatures().length).toBe(0);
-        });
-        it("emits a loading error event", async () => {
-          await vi.runAllTimersAsync();
-          expect(eventCallback).toHaveBeenCalledWith(
-            expect.objectContaining({
-              type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
-              error: expect.any(Error),
-              target: layer,
-            }),
-          );
-        });
-      });
-      describe("with remote file url", () => {
-        beforeEach(async () => {
-          layerModel = MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE;
-          layer = await createLayer(layerModel);
-          layer.on(
-            `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-            eventCallback,
-          );
-          layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-        });
-        it("create a VectorLayer", () => {
-          expect(layer).toBeTruthy();
-          expect(layer).toBeInstanceOf(VectorLayer);
-        });
-        it("create a VectorSource source", () => {
-          const source = layer.getSource();
-          expect(source).toBeInstanceOf(VectorSource);
-        });
-        it("sets the format as GeoJSON", () => {
-          const source = layer.getSource() as VectorSource;
-          expect(source.getFormat()).toBeInstanceOf(GeoJSON);
-        });
-        it("set the url to point to the file", () => {
-          const source = layer.getSource() as VectorSource;
-          expect(source.getUrl()).toBe(
-            (layerModel as MapContextLayerGeojson).url,
-          );
-        });
-        it("emits a loaded event when features load", () => {
-          const source = layer.getSource() as VectorSource;
-          source.dispatchEvent("featuresloadend");
-          expect(eventCallback).toHaveBeenCalledWith({
-            layerState: { loaded: true },
-            target: layer,
-            type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-          });
-        });
-      });
-      describe("with remote file url (failing to load)", () => {
-        beforeEach(async () => {
-          layerModel = MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE;
-          layer = await createLayer(layerModel);
-          layer.on(
-            `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
-            eventCallback,
-          );
-        });
-        it("creates a vector layer with an empty source", () => {
-          const source = layer.getSource() as VectorSource;
-          expect(layer).toBeInstanceOf(VectorLayer);
-          expect(source).toBeInstanceOf(VectorSource);
-          expect(source.getFeatures().length).toBe(0);
-        });
-        it("emits a loading error event when features fail to load", () => {
-          const source = layer.getSource() as VectorSource;
-          source.dispatchEvent("featuresloaderror");
-          expect(eventCallback).toHaveBeenCalledWith(
-            expect.objectContaining({
-              type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
-              error: expect.any(Error),
-              target: layer,
-            }),
-          );
-        });
-      });
-    });
-
-    describe("WMTS", () => {
-      beforeEach(async () => {
-        layerModel = MAP_CTX_LAYER_WMTS_FIXTURE;
-        layer = await createLayer(layerModel);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-      });
-      it("create a tile layer", () => {
-        expect(layer).toBeTruthy();
-        expect(layer).toBeInstanceOf(TileLayer);
-      });
-      it("set correct layer properties", () => {
-        expect(layer.getVisible()).toBe(true);
-        expect(layer.getOpacity()).toBe(1);
-        expect(layer.get("label")).toBeUndefined();
-        const source = layer.getSource() as WMTS;
-        expect(source.getAttributions()).toBeNull();
-        expect(source.getStyle()).toBe("default");
-      });
-      it("create a WMTS source", () => {
-        const source = layer.getSource();
-        expect(source).toBeInstanceOf(WMTS);
-      });
-      it("set correct urls", () => {
-        const source = layer.getSource() as WMTS;
-        const urls = source.getUrls() ?? [];
-        expect(urls).toEqual([
-          "https://services.geo.sg.ch/wss/service/SG00066_WMTS/guest/tile/1.0.0/SG00066/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}",
-        ]);
-      });
-      it("emits a loaded event initially", async () => {
-        await vi.runAllTimersAsync();
-        expect(eventCallback).toHaveBeenCalledWith({
-          layerState: {
-            loaded: true,
-          },
-          target: layer,
-          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-        });
-      });
-    });
-    describe("WMTS without default style given", () => {
-      beforeEach(async () => {
-        layerModel = {
-          ...MAP_CTX_LAYER_WMTS_FIXTURE,
-          url: "https://wmts/no-default-style",
-        };
-        layer = await createLayer(layerModel);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-      });
-      it("uses the first style as default", async () => {
-        const source = layer.getSource() as WMTS;
-        expect(source.getStyle()).toEqual("first");
-      });
-    });
-
-    describe("Maplibre Style", () => {
-      beforeEach(async () => {
-        layerModel = MAP_CTX_LAYER_MAPBLIBRE_STYLE_FIXTURE;
-        layer = await createLayer(layerModel);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-      });
-      it("create a tile layer", () => {
-        expect(layer).toBeTruthy();
-        expect(layer).toBeInstanceOf(MapboxVectorLayer);
-      });
-      it("set correct layer properties", () => {
-        expect(layer.getVisible()).toBe(true);
-        expect(layer.getOpacity()).toBe(1);
-        expect(layer.get("label")).toBeUndefined();
-      });
-      it("create a Vector Tile source", () => {
-        const source = layer.getSource();
-        expect(source).toBeInstanceOf(VectorTile);
-      });
-      it("emits a loaded event initially", async () => {
-        await vi.runAllTimersAsync();
-        expect(eventCallback).toHaveBeenCalledWith({
-          layerState: {
-            loaded: true,
-          },
-          target: layer,
-          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-        });
-      });
-    });
-
-    describe("MVT", () => {
-      beforeEach(async () => {
-        layerModel = MAP_CTX_LAYER_MVT_FIXTURE;
-        layer = await createLayer(layerModel);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
-        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
-      });
-      it("create a VectorTileLayer", () => {
-        expect(layer).toBeTruthy();
-        expect(layer).toBeInstanceOf(VectorTileLayer);
-      });
-      it("create a VectorTile source", () => {
-        const source = layer.getSource();
-        expect(source).toBeInstanceOf(VectorTile);
-      });
-      it("set correct layer properties", () => {
-        expect(layer.getVisible()).toBe(true);
-        expect(layer.getOpacity()).toBe(1);
-        expect(layer.get("label")).toBeUndefined();
-      });
-      it("emits a loaded event initially", async () => {
-        await vi.runAllTimersAsync();
-        expect(eventCallback).toHaveBeenCalledWith({
-          layerState: {
-            loaded: true,
-          },
-          target: layer,
-          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
-        });
-      });
-    });
-
-    describe("GeoTIFF", () => {
-      beforeEach(async () => {
-        layerModel = MAP_CTX_LAYER_GEOTIFF_FIXTURE;
-        layer = await createLayer(layerModel);
-      });
-      it("create a WebGLTile layer", () => {
-        expect(layer).toBeTruthy();
-        expect(layer).toBeInstanceOf(WebGLTileLayer);
-      });
-      it("set correct layer properties", () => {
-        expect(layer.getVisible()).toBe(true);
-        expect(layer.getOpacity()).toBe(1);
-        expect(layer.get("label")).toBeUndefined();
-      });
-      it("create a GeoTIFF source", () => {
-        const source = layer.getSource();
-        expect(source).toBeInstanceOf(GeoTIFF);
-      });
+    it("set zoom", () => {
+      const zoom = view.getZoom();
+      expect(zoom).toEqual(contextModel.view.zoom);
     });
   });
+  describe("from extent", () => {
+    const contextModel = {
+      ...MAP_CTX_FIXTURE,
+      view: { ...MAP_CTX_FIXTURE.view, extent: MAP_CTX_EXTENT_FIXTURE },
+    };
+    const map = new Map({});
+    map.setSize([100, 100]);
+    beforeEach(() => {
+      view = createView(contextModel.view, map);
+    });
+    it("create a view", () => {
+      expect(view).toBeTruthy();
+      expect(view).toBeInstanceOf(View);
+    });
+    it("set center", () => {
+      const center = view.getCenter();
+      expect(center).toEqual([317260.5487608297, 6623200.647707232]);
+    });
+    it("set zoom", () => {
+      const zoom = view.getZoom();
+      expect(zoom).toEqual(5);
+    });
+  });
+});
 
-  describe("#createView", () => {
+describe("resetMapFromContext", () => {
+  let map: Map;
+  beforeEach(async () => {
+    map = new Map({});
+    const mapContext = MAP_CTX_FIXTURE;
+    resetMapFromContext(map, mapContext);
+    await getMapUpdatesPromise(map);
+  });
+  it("create a map", () => {
+    expect(map).toBeTruthy();
+    expect(map).toBeInstanceOf(Map);
+  });
+  it("add layers", () => {
+    const layers = map.getLayers().getArray();
+    expect(layers.length).toEqual(3);
+  });
+  it("set view", () => {
+    const view = map.getView();
+    expect(view).toBeTruthy();
+    expect(view).toBeInstanceOf(View);
+  });
+  describe("uses default fallback view", () => {
     let view: View;
     let map: Map;
-    describe("from center and zoom", () => {
-      const contextModel = MAP_CTX_FIXTURE;
-      beforeEach(async () => {
-        map = await createMapFromContext(contextModel);
-        view = createView(contextModel.view, map);
-      });
-      it("create a view", () => {
-        expect(view).toBeTruthy();
-        expect(view).toBeInstanceOf(View);
-      });
-      it("set center", () => {
-        const center = view.getCenter();
-        expect(center).toEqual([862726.0536478702, 6207260.308175252]);
-      });
-      it("set zoom", () => {
-        const zoom = view.getZoom();
-        expect(zoom).toEqual(contextModel.view.zoom);
-      });
-    });
-    describe("from extent", () => {
-      const contextModel = {
-        ...MAP_CTX_FIXTURE,
-        view: { ...MAP_CTX_FIXTURE.view, extent: MAP_CTX_EXTENT_FIXTURE },
-      };
-      const map = new Map({});
-      map.setSize([100, 100]);
-      beforeEach(() => {
-        view = createView(contextModel.view, map);
-      });
-      it("create a view", () => {
-        expect(view).toBeTruthy();
-        expect(view).toBeInstanceOf(View);
-      });
-      it("set center", () => {
-        const center = view.getCenter();
-        expect(center).toEqual([317260.5487608297, 6623200.647707232]);
-      });
-      it("set zoom", () => {
-        const zoom = view.getZoom();
-        expect(zoom).toEqual(5);
-      });
-    });
-  });
-  describe("#resetMapFromContext", () => {
-    let map: Map;
-    beforeEach(() => {
+    beforeEach(async () => {
       map = new Map({});
-      const mapContext = MAP_CTX_FIXTURE;
+      const mapContext: MapContext = {
+        view: null,
+        layers: [
+          MAP_CTX_LAYER_XYZ_FIXTURE,
+          MAP_CTX_LAYER_WMS_FIXTURE,
+          MAP_CTX_LAYER_GEOJSON_FIXTURE,
+        ],
+      };
       resetMapFromContext(map, mapContext);
+      await getMapUpdatesPromise(map);
     });
     it("create a map", () => {
       expect(map).toBeTruthy();
@@ -806,46 +125,17 @@ describe("MapContextService", () => {
       expect(layers.length).toEqual(3);
     });
     it("set view", () => {
-      const view = map.getView();
+      view = map.getView();
       expect(view).toBeTruthy();
       expect(view).toBeInstanceOf(View);
     });
-    describe("uses default fallback view", () => {
-      let view: View;
-      let map: Map;
-      beforeEach(async () => {
-        map = new Map({});
-        const mapContext: MapContext = {
-          view: null,
-          layers: [
-            MAP_CTX_LAYER_XYZ_FIXTURE,
-            MAP_CTX_LAYER_WMS_FIXTURE,
-            MAP_CTX_LAYER_GEOJSON_FIXTURE,
-          ],
-        };
-        await resetMapFromContext(map, mapContext);
-      });
-      it("create a map", () => {
-        expect(map).toBeTruthy();
-        expect(map).toBeInstanceOf(Map);
-      });
-      it("add layers", () => {
-        const layers = map.getLayers().getArray();
-        expect(layers.length).toEqual(3);
-      });
-      it("set view", () => {
-        view = map.getView();
-        expect(view).toBeTruthy();
-        expect(view).toBeInstanceOf(View);
-      });
-      it("set center", () => {
-        const center = view.getCenter();
-        expect(center).toEqual([0, 0]);
-      });
-      it("set zoom", () => {
-        const zoom = view.getZoom();
-        expect(zoom).toEqual(0);
-      });
+    it("set center", () => {
+      const center = view.getCenter();
+      expect(center).toEqual([0, 0]);
+    });
+    it("set zoom", () => {
+      const zoom = view.getZoom();
+      expect(zoom).toEqual(0);
     });
   });
 });

--- a/packages/openlayers/lib/map/create-map.ts
+++ b/packages/openlayers/lib/map/create-map.ts
@@ -1,41 +1,14 @@
 import {
-  defaultStyle,
   MapContext,
   MapContextLayer,
   MapContextView,
-  removeSearchParams,
 } from "@geospatial-sdk/core";
 import Map from "ol/Map.js";
 import View from "ol/View.js";
 import Layer from "ol/layer/Layer.js";
-import TileLayer from "ol/layer/Tile.js";
-import XYZ from "ol/source/XYZ.js";
-import TileWMS from "ol/source/TileWMS.js";
-import VectorLayer from "ol/layer/Vector.js";
-import VectorSource from "ol/source/Vector.js";
 import GeoJSON from "ol/format/GeoJSON.js";
-import Feature from "ol/Feature.js";
-import Geometry from "ol/geom/Geometry.js";
 import SimpleGeometry from "ol/geom/SimpleGeometry.js";
 import { fromLonLat, transformExtent } from "ol/proj.js";
-import { bbox as bboxStrategy } from "ol/loadingstrategy.js";
-import VectorTileLayer from "ol/layer/VectorTile.js";
-import OGCMapTile from "ol/source/OGCMapTile.js";
-import OGCVectorTile from "ol/source/OGCVectorTile.js";
-import WMTS from "ol/source/WMTS.js";
-import MVT from "ol/format/MVT.js";
-import {
-  EndpointError,
-  OgcApiEndpoint,
-  WfsEndpoint,
-  WmtsEndpoint,
-} from "@camptocamp/ogc-client";
-import { MapboxVectorLayer } from "ol-mapbox-style";
-import { Tile } from "ol";
-import { tileLoadErrorCatchFunction } from "./handle-errors.js";
-import VectorTile from "ol/source/VectorTile.js";
-import GeoTIFF from "ol/source/GeoTIFF.js";
-import WebGLTileLayer from "ol/layer/WebGLTile.js";
 import proj4 from "proj4";
 import { register } from "ol/proj/proj4.js";
 import {
@@ -43,340 +16,15 @@ import {
   updateLayerProperties,
 } from "./layer-update.js";
 import { initHoverLayer } from "./feature-hover.js";
-import {
-  emitLayerCreationError,
-  emitLayerLoadingError,
-  emitLayerLoadingStatusSuccess,
-  propagateLayerStateChangeEventToMap,
-} from "./register-events.js";
+import { propagateLayerStateChangeEventToMap } from "./register-events.js";
+import { createLayer } from "./layer-creation.js";
 import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
-import { buildWmsParams } from "./wms-params.js";
-import ImageLayer from "ol/layer/Image.js";
-import ImageWMS from "ol/source/ImageWMS.js";
 
 // Register proj4 with OpenLayers so that arbitrary EPSG codes
 // (e.g., UTM zones from GeoTIFF metadata) can be reprojected to the map projection
 register(proj4);
 
 const GEOJSON = new GeoJSON();
-const WFS_MAX_FEATURES = 10000;
-
-// We need to defer some events being dispatched to make sure they are caught by the map
-// where the layers sit
-// FIXME: this should be better handled in a separate module!
-const defer = () => new Promise((resolve) => setTimeout(resolve, 0));
-
-export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
-  const { type } = layerModel;
-  let layer: Layer;
-
-  switch (type) {
-    case "xyz":
-      {
-        if (layerModel.tileFormat === "application/vnd.mapbox-vector-tile") {
-          layer = new VectorTileLayer({
-            source: new VectorTile({
-              format: new MVT(),
-              url: layerModel.url,
-              attributions: layerModel.attributions,
-            }),
-          });
-        } else {
-          layer = new TileLayer({});
-          const source = new XYZ({
-            url: layerModel.url,
-            referrerPolicy: layerModel.referrerPolicy,
-            attributions: layerModel.attributions,
-          });
-          source.setTileLoadFunction(function (tile: Tile, src: string) {
-            return tileLoadErrorCatchFunction(
-              layer as TileLayer<XYZ>,
-              tile,
-              src,
-            );
-          });
-          layer.setSource(source);
-        }
-        defer().then(() => emitLayerLoadingStatusSuccess(layer));
-      }
-      break;
-
-    case "wms":
-      {
-        const url = removeSearchParams(layerModel.url, ["request", "service"]);
-        const params = buildWmsParams(layerModel);
-        if (layerModel.useTiles === false) {
-          layer = new ImageLayer({
-            source: new ImageWMS({
-              url,
-              params,
-              referrerPolicy: layerModel.referrerPolicy,
-              attributions: layerModel.attributions,
-            }),
-          });
-        } else {
-          layer = new TileLayer({
-            source: new TileWMS({
-              url,
-              params: { ...params, TILED: true },
-              gutter: 20,
-              attributions: layerModel.attributions,
-              tileLoadFunction: function (tile: Tile, src: string) {
-                return tileLoadErrorCatchFunction(
-                  layer as TileLayer<TileWMS>,
-                  tile,
-                  src,
-                );
-              },
-            }),
-          });
-        }
-        defer().then(() => emitLayerLoadingStatusSuccess(layer));
-      }
-      break;
-
-    case "wmts": {
-      const olLayer = new TileLayer({});
-      const endpoint = new WmtsEndpoint(layerModel.url);
-      endpoint
-        .isReady()
-        .then(async (endpoint) => {
-          const layerName = endpoint.getSingleLayerName() ?? layerModel.name;
-          const layer = endpoint.getLayerByName(layerName);
-          const matrixSet = layer.matrixSets[0];
-          const tileGrid = await endpoint.getOpenLayersTileGrid(layer.name);
-          if (tileGrid === null) {
-            console.warn("A WMTS tile grid could not be created", layerModel);
-            return;
-          }
-          const resourceUrl = layer.resourceLinks[0];
-          const dimensions = endpoint.getDefaultDimensions(layer.name);
-          olLayer.setSource(
-            new WMTS({
-              layer: layer.name,
-              style: layer.defaultStyle || layer.styles[0].name,
-              matrixSet: matrixSet.identifier,
-              format: resourceUrl.format,
-              url: resourceUrl.url,
-              requestEncoding: resourceUrl.encoding,
-              referrerPolicy: layerModel.referrerPolicy,
-              tileGrid,
-              projection: matrixSet.crs,
-              dimensions,
-              attributions: layerModel.attributions,
-            }),
-          );
-        })
-        .then(() => emitLayerLoadingStatusSuccess(olLayer))
-        .catch((e) => {
-          const httpStatus =
-            e instanceof EndpointError ? e.httpStatus : undefined;
-          emitLayerLoadingError(olLayer, e, httpStatus);
-        });
-      layer = olLayer;
-      break;
-    }
-
-    case "wfs": {
-      const olLayer = new VectorLayer({
-        style: layerModel.style ?? defaultStyle,
-      });
-      new WfsEndpoint(layerModel.url)
-        .isReady()
-        .then((endpoint) => {
-          const featureType =
-            endpoint.getSingleFeatureTypeName() ?? layerModel.featureType;
-          olLayer.setSource(
-            new VectorSource({
-              format: new GeoJSON(),
-              url: function (extent) {
-                return endpoint.getFeatureUrl(featureType, {
-                  maxFeatures: WFS_MAX_FEATURES,
-                  asJson: true,
-                  outputCrs: "EPSG:3857",
-                  extent: extent as [number, number, number, number],
-                  extentCrs: "EPSG:3857",
-                });
-              },
-              strategy: bboxStrategy,
-              attributions: layerModel.attributions,
-            }),
-          );
-        })
-        .then(() => emitLayerLoadingStatusSuccess(olLayer))
-        .catch((e) => {
-          const httpStatus =
-            e instanceof EndpointError ? e.httpStatus : undefined;
-          emitLayerLoadingError(olLayer, e, httpStatus);
-        });
-      layer = olLayer;
-      break;
-    }
-
-    case "maplibre-style": {
-      layer = new MapboxVectorLayer({
-        styleUrl: layerModel.styleUrl,
-        accessToken: layerModel.accessToken,
-      }) as unknown as Layer;
-      defer().then(() => emitLayerLoadingStatusSuccess(layer));
-      break;
-    }
-
-    case "geojson": {
-      layer = new VectorLayer({
-        style: layerModel.style ?? defaultStyle,
-      });
-      let source: VectorSource;
-      if (layerModel.url !== undefined) {
-        source = new VectorSource({
-          format: new GeoJSON(),
-          url: layerModel.url,
-          attributions: layerModel.attributions,
-        });
-        source.once("featuresloadend", () =>
-          emitLayerLoadingStatusSuccess(layer),
-        );
-        source.once("featuresloaderror", () =>
-          emitLayerLoadingError(
-            layer,
-            new Error(
-              `GeoJSON features could not be loaded from: ${layerModel.url}`,
-            ),
-          ),
-        );
-      } else {
-        let geojson = layerModel.data;
-        try {
-          if (typeof geojson === "string") {
-            geojson = JSON.parse(geojson);
-          }
-          const features = GEOJSON.readFeatures(geojson, {
-            featureProjection: "EPSG:3857",
-            dataProjection: "EPSG:4326",
-          }) as Feature<Geometry>[];
-          source = new VectorSource({
-            features,
-            attributions: layerModel.attributions,
-          });
-          defer().then(() => emitLayerLoadingStatusSuccess(layer));
-        } catch (e) {
-          console.warn(
-            "GeoJSON layer data could not be parsed/read",
-            layerModel,
-            e,
-          );
-          source = new VectorSource({
-            features: [],
-            attributions: layerModel.attributions,
-          });
-          const err = e instanceof Error ? e : new Error(String(e));
-          defer().then(() => emitLayerLoadingError(layer, err));
-        }
-      }
-      layer.setSource(source);
-      break;
-    }
-
-    case "ogcapi": {
-      const ogcEndpoint = new OgcApiEndpoint(layerModel.url);
-      let layerUrl: string;
-      try {
-        if (layerModel.useTiles) {
-          if (layerModel.useTiles === "vector") {
-            layerUrl = await ogcEndpoint.getVectorTilesetUrl(
-              layerModel.collection,
-              layerModel.tileMatrixSet,
-            );
-            layer = new VectorTileLayer({
-              source: new OGCVectorTile({
-                url: layerUrl,
-                format: new MVT(),
-                attributions: layerModel.attributions,
-              }),
-            });
-          } else if (layerModel.useTiles === "map") {
-            layerUrl = await ogcEndpoint.getMapTilesetUrl(
-              layerModel.collection,
-              layerModel.tileMatrixSet,
-            );
-            layer = new TileLayer({
-              source: new OGCMapTile({
-                url: layerUrl,
-                attributions: layerModel.attributions,
-              }),
-            });
-          }
-        } else {
-          layerUrl = await ogcEndpoint.getCollectionItemsUrl(
-            layerModel.collection,
-            layerModel.options,
-          );
-          layer = new VectorLayer({
-            source: new VectorSource({
-              format: new GeoJSON(),
-              url: layerUrl,
-              attributions: layerModel.attributions,
-            }),
-            style: layerModel.style ?? defaultStyle,
-          });
-        }
-        defer().then(() => emitLayerLoadingStatusSuccess(layer));
-      } catch (e) {
-        if (layerModel.useTiles === "vector") {
-          layer = new VectorTileLayer({
-            properties: { [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true },
-          });
-        } else if (layerModel.useTiles === "map") {
-          layer = new TileLayer({
-            properties: { [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true },
-          });
-        } else {
-          layer = new VectorLayer({
-            style: layerModel.style ?? defaultStyle,
-            properties: { [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true },
-          });
-        }
-        const httpStatus =
-          e instanceof EndpointError ? e.httpStatus : undefined;
-        const err = e instanceof Error ? e : new Error(String(e));
-        defer().then(() => emitLayerLoadingError(layer, err, httpStatus));
-      }
-      break;
-    }
-
-    case "geotiff": {
-      const geoTiffSource = new GeoTIFF({
-        sources: [{ url: layerModel.url }],
-        convertToRGB: "auto",
-      });
-      layer = new WebGLTileLayer({
-        source: geoTiffSource,
-      });
-      // FIXME: actually track tile loading
-      defer().then(() => emitLayerLoadingStatusSuccess(layer));
-      break;
-    }
-
-    default: {
-      // we create an empty placeholder layer so that we still have a corresponding layer in OL
-      layer = new VectorLayer({
-        properties: {
-          [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true,
-        },
-      });
-      defer().then(() =>
-        emitLayerCreationError(
-          layer,
-          new Error(`Unrecognized layer type: ${JSON.stringify(layerModel)}`),
-        ),
-      );
-    }
-  }
-
-  updateLayerProperties(layerModel, layer!);
-
-  return layer!;
-}
 
 export async function updateLayerInMap(
   map: Map,
@@ -442,32 +90,53 @@ export function createView(viewModel: MapContextView | null, map: Map): View {
  * @param context
  * @param target
  */
-export async function createMapFromContext(
+export function createMapFromContext(
   context: MapContext,
   target?: string | HTMLElement,
-): Promise<Map> {
+): Map {
   const map = new Map({
     target,
   });
-  return await resetMapFromContext(map, context);
+  return resetMapFromContext(map, context);
 }
 
 /**
- * Resets an OpenLayers map from a context; existing content will be cleared
+ * Resets an OpenLayers map from a context; existing content will be cleared.
+ * The function returns synchronously; all asynchronous modifications are stacked
+ * in a promise chain stored on the map.
  * @param map
  * @param context
  */
-export async function resetMapFromContext(
-  map: Map,
-  context: MapContext,
-): Promise<Map> {
+export function resetMapFromContext(map: Map, context: MapContext): Map {
   map.setView(createView(context.view, map));
   map.getLayers().clear();
-  for (const layerModel of context.layers) {
-    const layer = await createLayer(layerModel);
-    map.addLayer(layer);
-    propagateLayerStateChangeEventToMap(map, layer);
-  }
-  initHoverLayer(map);
+  const existingChain: Promise<void> =
+    map.get(`${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`) ??
+    Promise.resolve();
+  map.set(
+    `${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`,
+    existingChain
+      .then(async () => {
+        for (const layerModel of context.layers) {
+          const layer = await createLayer(layerModel);
+          map.addLayer(layer);
+          propagateLayerStateChangeEventToMap(map, layer);
+        }
+      })
+      .then(() => {
+        initHoverLayer(map);
+      }),
+  );
   return map;
+}
+
+/**
+ * This promise will resolve once all pending modifications are done on the map.
+ * @param map
+ */
+export function getMapUpdatesPromise(map: Map): Promise<void> {
+  return (
+    map.get(`${GEOSPATIAL_SDK_PREFIX}apply-layer-promise-chain`) ??
+    Promise.resolve()
+  );
 }

--- a/packages/openlayers/lib/map/layer-creation.test.ts
+++ b/packages/openlayers/lib/map/layer-creation.test.ts
@@ -1,0 +1,705 @@
+import {
+  MapContextLayer,
+  MapContextLayerGeojson,
+  MapContextLayerWms,
+} from "@geospatial-sdk/core";
+import {
+  MAP_CTX_LAYER_GEOJSON_FIXTURE,
+  MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE,
+  MAP_CTX_LAYER_GEOTIFF_FIXTURE,
+  MAP_CTX_LAYER_MAPBLIBRE_STYLE_FIXTURE,
+  MAP_CTX_LAYER_MVT_FIXTURE,
+  MAP_CTX_LAYER_OGCAPI_FIXTURE,
+  MAP_CTX_LAYER_WFS_FIXTURE,
+  MAP_CTX_LAYER_WMS_FIXTURE,
+  MAP_CTX_LAYER_WMTS_FIXTURE,
+  MAP_CTX_LAYER_XYZ_FIXTURE,
+} from "@geospatial-sdk/core/fixtures/map-context.fixtures.js";
+import { FeatureCollection } from "geojson";
+import { MapboxVectorLayer } from "ol-mapbox-style";
+import { FeatureUrlFunction } from "ol/featureloader.js";
+import GeoJSON from "ol/format/GeoJSON.js";
+import ImageTile from "ol/ImageTile.js";
+import Layer from "ol/layer/Layer.js";
+import TileLayer from "ol/layer/Tile.js";
+import VectorLayer from "ol/layer/Vector.js";
+import VectorTileLayer from "ol/layer/VectorTile.js";
+import WebGLTileLayer from "ol/layer/WebGLTile.js";
+import { VectorTile } from "ol/source.js";
+import GeoTIFF from "ol/source/GeoTIFF.js";
+import TileWMS from "ol/source/TileWMS.js";
+import VectorSource from "ol/source/Vector.js";
+import WMTS from "ol/source/WMTS.js";
+import XYZ from "ol/source/XYZ.js";
+import TileState from "ol/TileState.js";
+import { beforeEach } from "vitest";
+import { tileLoadErrorCatchFunction } from "./handle-errors.js";
+import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
+import ImageLayer from "ol/layer/Image.js";
+import ImageWMS from "ol/source/ImageWMS.js";
+import { OgcApiEndpoint } from "@camptocamp/ogc-client";
+import { createLayer } from "./layer-creation.js";
+
+vi.mock("./handle-errors", async (importOriginal) => {
+  const actual =
+    (await importOriginal()) as typeof import("./handle-errors.js");
+  return {
+    ...actual,
+    tileLoadErrorCatchFunction: vi.fn(),
+    handleEndpointError: vi.fn(),
+  };
+});
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  vi.clearAllMocks();
+});
+
+describe("createLayer", () => {
+  let layerModel: MapContextLayer, layer: Layer;
+  const eventCallback = vi.fn();
+
+  describe("XYZ", () => {
+    beforeEach(async () => {
+      layerModel = MAP_CTX_LAYER_XYZ_FIXTURE;
+      layer = await createLayer(layerModel);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+    });
+    it("create a tile layer", () => {
+      expect(layer).toBeTruthy();
+      expect(layer).toBeInstanceOf(TileLayer);
+    });
+    it("set correct layer properties", () => {
+      expect(layer.getVisible()).toBe(true);
+      expect(layer.getOpacity()).toBe(1);
+      expect(layer.get("label")).toBeUndefined();
+      expect(layer.getSource()?.getAttributions()).toBeNull();
+    });
+    it("create a XYZ source", () => {
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(XYZ);
+    });
+    it("set correct urls", () => {
+      const source = layer.getSource() as XYZ;
+      const urls = source.getUrls() ?? [];
+      expect(urls.length).toBe(3);
+      expect(urls[0]).toEqual(
+        "https://a.tile.openstreetmap.org/{z}/{x}/{y}.png",
+      );
+    });
+    it("should set tileLoadErrorCatchFunction to handle errors", () => {
+      const source = layer.getSource() as XYZ;
+      const tileLoadFunction = source.getTileLoadFunction();
+      expect(tileLoadFunction).toBeInstanceOf(Function);
+      const tile = new ImageTile([0, 0, 0], TileState.IDLE, "", null, () => {});
+      tileLoadFunction(tile, "http://example.com/tile");
+      expect(tileLoadErrorCatchFunction).toHaveBeenCalled();
+    });
+    it("should configure XYZ source with referrerPolicy from layer model", async () => {
+      const layerWithPolicy = await createLayer({
+        ...MAP_CTX_LAYER_XYZ_FIXTURE,
+        referrerPolicy: "strict-origin-when-cross-origin",
+      });
+      const source = layerWithPolicy.getSource() as XYZ;
+      // referrerPolicy is protected on TileImage; access via bracket to verify it is set
+      expect(
+        (source as unknown as Record<string, unknown>)["referrerPolicy"],
+      ).toBe("strict-origin-when-cross-origin");
+    });
+    it("emits a loaded event initially", async () => {
+      await vi.runAllTimersAsync();
+      expect(eventCallback).toHaveBeenCalledWith({
+        layerState: {
+          loaded: true,
+        },
+        target: layer,
+        type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+      });
+    });
+  });
+  describe("OGCAPI (as geojson items)", () => {
+    beforeEach(async () => {
+      layerModel = MAP_CTX_LAYER_OGCAPI_FIXTURE;
+      layer = await createLayer(layerModel);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+    });
+    it("create a vector layer", () => {
+      expect(layer).toBeTruthy();
+      expect(layer).toBeInstanceOf(VectorLayer);
+    });
+    it("set correct layer properties", () => {
+      expect(layer.getVisible()).toBe(true);
+      expect(layer.getOpacity()).toBe(1);
+      expect(layer.get("label")).toBeUndefined();
+      expect(layer.getSource()?.getAttributions()).toBeNull();
+    });
+    it("create a vector source", () => {
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(VectorSource);
+    });
+    it("set correct url", () => {
+      const source = layer.getSource() as VectorSource;
+      const url = source.getUrl();
+      expect(url).toBe(
+        "https://demo.ldproxy.net/zoomstack/collections/airports/items?f=json",
+      );
+    });
+    it("emits a loaded event initially", async () => {
+      await vi.runAllTimersAsync();
+      expect(eventCallback).toHaveBeenCalledWith({
+        layerState: {
+          loaded: true,
+        },
+        target: layer,
+        type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+      });
+    });
+  });
+  describe("OGCAPI (with failing endpoint)", () => {
+    beforeEach(async () => {
+      vi.spyOn(
+        OgcApiEndpoint.prototype,
+        "getCollectionItemsUrl",
+      ).mockRejectedValue(new Error("Failed to load collection"));
+      layerModel = MAP_CTX_LAYER_OGCAPI_FIXTURE;
+      layer = await createLayer(layerModel);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-error`, eventCallback);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it("creates an empty vector layer", () => {
+      expect(layer).toBeInstanceOf(VectorLayer);
+      expect(layer.getSource()).toBeNull();
+    });
+
+    it("emits a loading error event", async () => {
+      await vi.runAllTimersAsync();
+      expect(eventCallback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
+          error: expect.any(Error),
+          target: layer,
+        }),
+      );
+    });
+  });
+  describe("WMS", () => {
+    beforeEach(async () => {
+      layerModel = MAP_CTX_LAYER_WMS_FIXTURE;
+      layer = await createLayer(layerModel);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+    });
+    it("create a tile layer", () => {
+      expect(layer).toBeTruthy();
+      expect(layer).toBeInstanceOf(TileLayer);
+    });
+    it("set correct layer properties", () => {
+      expect(layer.getVisible()).toBe(false);
+      expect(layer.getOpacity()).toBe(0.5);
+      expect(layer.get("label")).toBe("Communes");
+      // @ts-expect-error TS2554 we're not providing a view extent here
+      expect(layer.getSource()?.getAttributions()!()).toEqual(["camptocamp"]);
+    });
+    it("create a TileWMS source", () => {
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(TileWMS);
+    });
+    it("set correct WMS params", () => {
+      const source = layer.getSource() as TileWMS;
+      const params = source.getParams();
+      expect(params).toEqual({
+        LAYERS: (layerModel as MapContextLayerWms).name,
+        STYLES: (layerModel as MapContextLayerWms).style,
+        TILED: true,
+      });
+    });
+    it("sets custom WMS FORMAT param when provided", async () => {
+      layerModel = { ...MAP_CTX_LAYER_WMS_FIXTURE, format: "image/jpeg" };
+      layer = await createLayer(layerModel);
+      const source = layer.getSource() as TileWMS;
+      const params = source.getParams();
+      expect(params).toEqual({
+        LAYERS: (layerModel as MapContextLayerWms).name,
+        FORMAT: "image/jpeg",
+        STYLES: (layerModel as MapContextLayerWms).style,
+        TILED: true,
+      });
+    });
+    it("sets WMS dimension params with uppercased keys and ISO Date values", async () => {
+      layerModel = {
+        ...MAP_CTX_LAYER_WMS_FIXTURE,
+        dimensionValues: {
+          time: new Date("2020-01-01T00:00:00.000Z"),
+          elevation: 500,
+        },
+      };
+      layer = await createLayer(layerModel);
+      const source = layer.getSource() as TileWMS;
+      const params = source.getParams();
+      expect(params).toEqual({
+        LAYERS: (layerModel as MapContextLayerWms).name,
+        STYLES: (layerModel as MapContextLayerWms).style,
+        TILED: true,
+        TIME: "2020-01-01T00:00:00.000Z",
+        ELEVATION: 500,
+      });
+    });
+    it("set correct url without existing REQUEST and SERVICE params", () => {
+      const source = layer.getSource() as TileWMS;
+      const urls = source.getUrls() || [];
+      expect(urls.length).toBe(1);
+      expect(urls[0]).toBe(
+        "https://www.datagrandest.fr/geoserver/region-grand-est/ows",
+      );
+    });
+    it("set WMS gutter of 20px", () => {
+      const source = layer.getSource() as TileWMS;
+      const gutter = source["gutter_"];
+      expect(gutter).toBe(20);
+    });
+    it("should set tileLoadErrorCatchFunction to handle errors", () => {
+      const source = layer.getSource() as TileWMS;
+      const tileLoadFunction = source.getTileLoadFunction();
+      expect(tileLoadFunction).toBeInstanceOf(Function);
+      const tile = new ImageTile([0, 0, 0], TileState.IDLE, "", null, () => {});
+      tileLoadFunction(tile, "http://example.com/tile");
+      expect(tileLoadErrorCatchFunction).toHaveBeenCalled();
+    });
+
+    it("emits a loaded event initially", async () => {
+      await vi.runAllTimersAsync();
+      expect(eventCallback).toHaveBeenCalledWith({
+        layerState: {
+          loaded: true,
+        },
+        target: layer,
+        type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+      });
+    });
+
+    describe("not using tiles", () => {
+      beforeEach(async () => {
+        layerModel = { ...MAP_CTX_LAYER_WMS_FIXTURE, useTiles: false };
+        layer = await createLayer(layerModel);
+        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+      });
+      it("create an image layer", () => {
+        expect(layer).toBeTruthy();
+        expect(layer).toBeInstanceOf(ImageLayer);
+      });
+      it("set correct layer properties", () => {
+        expect(layer.getVisible()).toBe(false);
+        expect(layer.getOpacity()).toBe(0.5);
+        expect(layer.get("label")).toBe("Communes");
+        // @ts-expect-error TS2554 we're not providing a view extent here
+        expect(layer.getSource()?.getAttributions()!()).toEqual(["camptocamp"]);
+      });
+      it("create an ImageWMS source", () => {
+        const source = layer.getSource();
+        expect(source).toBeInstanceOf(ImageWMS);
+      });
+      it("set correct WMS params", () => {
+        const source = layer.getSource() as ImageWMS;
+        const params = source.getParams();
+        expect(params).toEqual({
+          LAYERS: (layerModel as MapContextLayerWms).name,
+          STYLES: (layerModel as MapContextLayerWms).style,
+        });
+      });
+      it("sets custom WMS FORMAT param when provided", async () => {
+        layerModel = {
+          ...MAP_CTX_LAYER_WMS_FIXTURE,
+          useTiles: false,
+          format: "image/jpeg",
+        };
+        layer = await createLayer(layerModel);
+        const source = layer.getSource() as ImageWMS;
+        const params = source.getParams();
+        expect(params).toEqual({
+          LAYERS: (layerModel as MapContextLayerWms).name,
+          FORMAT: "image/jpeg",
+          STYLES: (layerModel as MapContextLayerWms).style,
+        });
+      });
+      it("sets WMS dimension params with uppercased keys and ISO Date values", async () => {
+        layerModel = {
+          ...MAP_CTX_LAYER_WMS_FIXTURE,
+          useTiles: false,
+          dimensionValues: {
+            time: new Date("2020-01-01T00:00:00.000Z"),
+            elevation: 500,
+          },
+        };
+        layer = await createLayer(layerModel);
+        const source = layer.getSource() as ImageWMS;
+        const params = source.getParams();
+        expect(params).toEqual({
+          LAYERS: (layerModel as MapContextLayerWms).name,
+          STYLES: (layerModel as MapContextLayerWms).style,
+          TIME: "2020-01-01T00:00:00.000Z",
+          ELEVATION: 500,
+        });
+      });
+      it("set correct url without existing REQUEST and SERVICE params", () => {
+        const source = layer.getSource() as ImageWMS;
+        const url = source.getUrl();
+        expect(url).toBe(
+          "https://www.datagrandest.fr/geoserver/region-grand-est/ows",
+        );
+      });
+    });
+  });
+
+  describe("WFS", () => {
+    beforeEach(async () => {
+      layerModel = MAP_CTX_LAYER_WFS_FIXTURE;
+      layer = await createLayer(layerModel);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+    });
+    it("create a vector layer", () => {
+      expect(layer).toBeTruthy();
+      expect(layer).toBeInstanceOf(VectorLayer);
+    });
+    it("set correct layer properties", () => {
+      expect(layer.getVisible()).toBe(true);
+      expect(layer.getOpacity()).toBe(0.5);
+      expect(layer.get("label")).toBe("Communes");
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(VectorSource);
+
+      const attributions = layer.getSource()?.getAttributions();
+      expect(attributions).not.toBeNull();
+      // @ts-expect-error TS2554 we're not providing a view extent here
+      expect(attributions!()).toEqual(["camptocamp"]);
+    });
+    it("create a Vector source", () => {
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(VectorSource);
+    });
+    it("set correct url load function", () => {
+      const source = layer.getSource() as VectorSource;
+      const urlLoader = source.getUrl() as FeatureUrlFunction;
+      // @ts-expect-error TS2345
+      expect(urlLoader([10, 20, 30, 40])).toBe(
+        "https://www.datagrandest.fr/geoserver/region-grand-est/ows?service=WFS&version=1.1.0&request=GetFeature&outputFormat=application%2Fjson&typename=ms%3Acommune_actuelle_3857&srsname=EPSG%3A3857&bbox=10%2C20%2C30%2C40%2CEPSG%3A3857&maxFeatures=10000",
+      );
+    });
+    it("emits a loaded event initially", async () => {
+      await vi.runAllTimersAsync();
+      expect(eventCallback).toHaveBeenCalledWith({
+        layerState: {
+          loaded: true,
+        },
+        target: layer,
+        type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+      });
+    });
+  });
+
+  describe("GEOJSON", () => {
+    describe("with inline data", () => {
+      beforeEach(async () => {
+        layerModel = MAP_CTX_LAYER_GEOJSON_FIXTURE;
+        layer = await createLayer(layerModel);
+        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+      });
+      it("create a VectorLayer", () => {
+        expect(layer).toBeTruthy();
+        expect(layer).toBeInstanceOf(VectorLayer);
+      });
+      it("set correct layer properties", () => {
+        expect(layer.getVisible()).toBe(true);
+        expect(layer.getOpacity()).toBe(0.8);
+        expect(layer.get("label")).toBe("Regions");
+      });
+      it("create a VectorSource source", () => {
+        const source = layer.getSource();
+        expect(source).toBeInstanceOf(VectorSource);
+      });
+      it("add features", () => {
+        const source = layer.getSource() as VectorSource;
+        const features = source.getFeatures();
+        const data = (layerModel as MapContextLayerGeojson)
+          .data as FeatureCollection;
+        expect(features.length).toBe(data.features.length);
+      });
+      it("emits a loaded event", async () => {
+        await vi.runAllTimersAsync();
+        expect(eventCallback).toHaveBeenCalledWith({
+          layerState: {
+            loaded: true,
+          },
+          target: layer,
+          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+        });
+      });
+    });
+    describe("with inline data as string", () => {
+      beforeEach(async () => {
+        layerModel = { ...MAP_CTX_LAYER_GEOJSON_FIXTURE };
+        layerModel.data = JSON.stringify(layerModel.data);
+        layer = await createLayer(layerModel);
+      });
+      it("create a VectorLayer", () => {
+        expect(layer).toBeTruthy();
+        expect(layer).toBeInstanceOf(VectorLayer);
+      });
+      it("create a VectorSource source", () => {
+        const source = layer.getSource();
+        expect(source).toBeInstanceOf(VectorSource);
+      });
+      it("add features", () => {
+        const source = layer.getSource() as VectorSource;
+        const features = source.getFeatures();
+        expect(features.length).toBe(
+          (MAP_CTX_LAYER_GEOJSON_FIXTURE.data as FeatureCollection).features
+            .length,
+        );
+      });
+    });
+    describe("with invalid inline data as string", () => {
+      beforeEach(async () => {
+        const spy = vi.spyOn(window.console, "warn");
+        spy.mockClear();
+        layerModel = {
+          ...MAP_CTX_LAYER_GEOJSON_FIXTURE,
+          url: undefined,
+          data: "blargz",
+        };
+        layer = await createLayer(layerModel);
+        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-error`, eventCallback);
+      });
+      it("create a VectorLayer", () => {
+        expect(layer).toBeTruthy();
+        expect(layer).toBeInstanceOf(VectorLayer);
+      });
+      it("outputs error in the console", () => {
+        expect(window.console.warn).toHaveBeenCalled();
+      });
+      it("create an empty VectorSource source", () => {
+        const source = layer.getSource() as VectorSource;
+        expect(source).toBeInstanceOf(VectorSource);
+        expect(source.getFeatures().length).toBe(0);
+      });
+      it("emits a loading error event", async () => {
+        await vi.runAllTimersAsync();
+        expect(eventCallback).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
+            error: expect.any(Error),
+            target: layer,
+          }),
+        );
+      });
+    });
+    describe("with remote file url", () => {
+      beforeEach(async () => {
+        layerModel = MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE;
+        layer = await createLayer(layerModel);
+        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+      });
+      it("create a VectorLayer", () => {
+        expect(layer).toBeTruthy();
+        expect(layer).toBeInstanceOf(VectorLayer);
+      });
+      it("create a VectorSource source", () => {
+        const source = layer.getSource();
+        expect(source).toBeInstanceOf(VectorSource);
+      });
+      it("sets the format as GeoJSON", () => {
+        const source = layer.getSource() as VectorSource;
+        expect(source.getFormat()).toBeInstanceOf(GeoJSON);
+      });
+      it("set the url to point to the file", () => {
+        const source = layer.getSource() as VectorSource;
+        expect(source.getUrl()).toBe(
+          (layerModel as MapContextLayerGeojson).url,
+        );
+      });
+      it("emits a loaded event when features load", () => {
+        const source = layer.getSource() as VectorSource;
+        source.dispatchEvent("featuresloadend");
+        expect(eventCallback).toHaveBeenCalledWith({
+          layerState: { loaded: true },
+          target: layer,
+          type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+        });
+      });
+    });
+    describe("with remote file url (failing to load)", () => {
+      beforeEach(async () => {
+        layerModel = MAP_CTX_LAYER_GEOJSON_REMOTE_FIXTURE;
+        layer = await createLayer(layerModel);
+        layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-error`, eventCallback);
+      });
+      it("creates a vector layer with an empty source", () => {
+        const source = layer.getSource() as VectorSource;
+        expect(layer).toBeInstanceOf(VectorLayer);
+        expect(source).toBeInstanceOf(VectorSource);
+        expect(source.getFeatures().length).toBe(0);
+      });
+      it("emits a loading error event when features fail to load", () => {
+        const source = layer.getSource() as VectorSource;
+        source.dispatchEvent("featuresloaderror");
+        expect(eventCallback).toHaveBeenCalledWith(
+          expect.objectContaining({
+            type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-error`,
+            error: expect.any(Error),
+            target: layer,
+          }),
+        );
+      });
+    });
+  });
+
+  describe("WMTS", () => {
+    beforeEach(async () => {
+      layerModel = MAP_CTX_LAYER_WMTS_FIXTURE;
+      layer = await createLayer(layerModel);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+    });
+    it("create a tile layer", () => {
+      expect(layer).toBeTruthy();
+      expect(layer).toBeInstanceOf(TileLayer);
+    });
+    it("set correct layer properties", () => {
+      expect(layer.getVisible()).toBe(true);
+      expect(layer.getOpacity()).toBe(1);
+      expect(layer.get("label")).toBeUndefined();
+      const source = layer.getSource() as WMTS;
+      expect(source.getAttributions()).toBeNull();
+      expect(source.getStyle()).toBe("default");
+    });
+    it("create a WMTS source", () => {
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(WMTS);
+    });
+    it("set correct urls", () => {
+      const source = layer.getSource() as WMTS;
+      const urls = source.getUrls() ?? [];
+      expect(urls).toEqual([
+        "https://services.geo.sg.ch/wss/service/SG00066_WMTS/guest/tile/1.0.0/SG00066/{Style}/{TileMatrixSet}/{TileMatrix}/{TileRow}/{TileCol}",
+      ]);
+    });
+    it("emits a loaded event initially", async () => {
+      await vi.runAllTimersAsync();
+      expect(eventCallback).toHaveBeenCalledWith({
+        layerState: {
+          loaded: true,
+        },
+        target: layer,
+        type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+      });
+    });
+  });
+  describe("WMTS without default style given", () => {
+    beforeEach(async () => {
+      layerModel = {
+        ...MAP_CTX_LAYER_WMTS_FIXTURE,
+        url: "https://wmts/no-default-style",
+      };
+      layer = await createLayer(layerModel);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+    });
+    it("uses the first style as default", async () => {
+      const source = layer.getSource() as WMTS;
+      expect(source.getStyle()).toEqual("first");
+    });
+  });
+
+  describe("Maplibre Style", () => {
+    beforeEach(async () => {
+      layerModel = MAP_CTX_LAYER_MAPBLIBRE_STYLE_FIXTURE;
+      layer = await createLayer(layerModel);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+    });
+    it("create a tile layer", () => {
+      expect(layer).toBeTruthy();
+      expect(layer).toBeInstanceOf(MapboxVectorLayer);
+    });
+    it("set correct layer properties", () => {
+      expect(layer.getVisible()).toBe(true);
+      expect(layer.getOpacity()).toBe(1);
+      expect(layer.get("label")).toBeUndefined();
+    });
+    it("create a Vector Tile source", () => {
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(VectorTile);
+    });
+    it("emits a loaded event initially", async () => {
+      await vi.runAllTimersAsync();
+      expect(eventCallback).toHaveBeenCalledWith({
+        layerState: {
+          loaded: true,
+        },
+        target: layer,
+        type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+      });
+    });
+  });
+
+  describe("MVT", () => {
+    beforeEach(async () => {
+      layerModel = MAP_CTX_LAYER_MVT_FIXTURE;
+      layer = await createLayer(layerModel);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-loading-status`, eventCallback);
+      layer.on(`${GEOSPATIAL_SDK_PREFIX}layer-data-info`, eventCallback);
+    });
+    it("create a VectorTileLayer", () => {
+      expect(layer).toBeTruthy();
+      expect(layer).toBeInstanceOf(VectorTileLayer);
+    });
+    it("create a VectorTile source", () => {
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(VectorTile);
+    });
+    it("set correct layer properties", () => {
+      expect(layer.getVisible()).toBe(true);
+      expect(layer.getOpacity()).toBe(1);
+      expect(layer.get("label")).toBeUndefined();
+    });
+    it("emits a loaded event initially", async () => {
+      await vi.runAllTimersAsync();
+      expect(eventCallback).toHaveBeenCalledWith({
+        layerState: {
+          loaded: true,
+        },
+        target: layer,
+        type: `${GEOSPATIAL_SDK_PREFIX}layer-loading-status`,
+      });
+    });
+  });
+
+  describe("GeoTIFF", () => {
+    beforeEach(async () => {
+      layerModel = MAP_CTX_LAYER_GEOTIFF_FIXTURE;
+      layer = await createLayer(layerModel);
+    });
+    it("create a WebGLTile layer", () => {
+      expect(layer).toBeTruthy();
+      expect(layer).toBeInstanceOf(WebGLTileLayer);
+    });
+    it("set correct layer properties", () => {
+      expect(layer.getVisible()).toBe(true);
+      expect(layer.getOpacity()).toBe(1);
+      expect(layer.get("label")).toBeUndefined();
+    });
+    it("create a GeoTIFF source", () => {
+      const source = layer.getSource();
+      expect(source).toBeInstanceOf(GeoTIFF);
+    });
+  });
+});

--- a/packages/openlayers/lib/map/layer-creation.ts
+++ b/packages/openlayers/lib/map/layer-creation.ts
@@ -1,0 +1,362 @@
+import {
+  defaultStyle,
+  MapContextLayer,
+  removeSearchParams,
+} from "@geospatial-sdk/core";
+import Layer from "ol/layer/Layer.js";
+import TileLayer from "ol/layer/Tile.js";
+import XYZ from "ol/source/XYZ.js";
+import TileWMS from "ol/source/TileWMS.js";
+import VectorLayer from "ol/layer/Vector.js";
+import VectorSource from "ol/source/Vector.js";
+import GeoJSON from "ol/format/GeoJSON.js";
+import Feature from "ol/Feature.js";
+import Geometry from "ol/geom/Geometry.js";
+import { bbox as bboxStrategy } from "ol/loadingstrategy.js";
+import VectorTileLayer from "ol/layer/VectorTile.js";
+import OGCMapTile from "ol/source/OGCMapTile.js";
+import OGCVectorTile from "ol/source/OGCVectorTile.js";
+import WMTS from "ol/source/WMTS.js";
+import MVT from "ol/format/MVT.js";
+import {
+  EndpointError,
+  OgcApiEndpoint,
+  WfsEndpoint,
+  WmtsEndpoint,
+} from "@camptocamp/ogc-client";
+import { MapboxVectorLayer } from "ol-mapbox-style";
+import { Tile } from "ol";
+import { tileLoadErrorCatchFunction } from "./handle-errors.js";
+import VectorTile from "ol/source/VectorTile.js";
+import GeoTIFF from "ol/source/GeoTIFF.js";
+import WebGLTileLayer from "ol/layer/WebGLTile.js";
+import { updateLayerProperties } from "./layer-update.js";
+import {
+  emitLayerCreationError,
+  emitLayerLoadingError,
+  emitLayerLoadingStatusSuccess,
+} from "./register-events.js";
+import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
+import { buildWmsParams } from "./wms-params.js";
+import ImageLayer from "ol/layer/Image.js";
+import ImageWMS from "ol/source/ImageWMS.js";
+
+const GEOJSON = new GeoJSON();
+const WFS_MAX_FEATURES = 10000;
+
+// We need to defer some events being dispatched to make sure they are caught by the map
+// where the layers sit
+// FIXME: this should be better handled in a separate module!
+const defer = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+export async function createLayer(layerModel: MapContextLayer): Promise<Layer> {
+  const { type } = layerModel;
+  let layer: Layer;
+
+  switch (type) {
+    case "xyz":
+      {
+        if (layerModel.tileFormat === "application/vnd.mapbox-vector-tile") {
+          layer = new VectorTileLayer({
+            source: new VectorTile({
+              format: new MVT(),
+              url: layerModel.url,
+              attributions: layerModel.attributions,
+            }),
+          });
+        } else {
+          layer = new TileLayer({});
+          const source = new XYZ({
+            url: layerModel.url,
+            referrerPolicy: layerModel.referrerPolicy,
+            attributions: layerModel.attributions,
+          });
+          source.setTileLoadFunction(function (tile: Tile, src: string) {
+            return tileLoadErrorCatchFunction(
+              layer as TileLayer<XYZ>,
+              tile,
+              src,
+            );
+          });
+          layer.setSource(source);
+        }
+        defer().then(() => emitLayerLoadingStatusSuccess(layer));
+      }
+      break;
+
+    case "wms":
+      {
+        const url = removeSearchParams(layerModel.url, ["request", "service"]);
+        const params = buildWmsParams(layerModel);
+        if (layerModel.useTiles === false) {
+          layer = new ImageLayer({
+            source: new ImageWMS({
+              url,
+              params,
+              referrerPolicy: layerModel.referrerPolicy,
+              attributions: layerModel.attributions,
+            }),
+          });
+        } else {
+          layer = new TileLayer({
+            source: new TileWMS({
+              url,
+              params: { ...params, TILED: true },
+              gutter: 20,
+              attributions: layerModel.attributions,
+              tileLoadFunction: function (tile: Tile, src: string) {
+                return tileLoadErrorCatchFunction(
+                  layer as TileLayer<TileWMS>,
+                  tile,
+                  src,
+                );
+              },
+            }),
+          });
+        }
+        defer().then(() => emitLayerLoadingStatusSuccess(layer));
+      }
+      break;
+
+    case "wmts": {
+      const olLayer = new TileLayer({});
+      const endpoint = new WmtsEndpoint(layerModel.url);
+      endpoint
+        .isReady()
+        .then(async (endpoint) => {
+          const layerName = endpoint.getSingleLayerName() ?? layerModel.name;
+          const layer = endpoint.getLayerByName(layerName);
+          const matrixSet = layer.matrixSets[0];
+          const tileGrid = await endpoint.getOpenLayersTileGrid(layer.name);
+          if (tileGrid === null) {
+            console.warn("A WMTS tile grid could not be created", layerModel);
+            return;
+          }
+          const resourceUrl = layer.resourceLinks[0];
+          const dimensions = endpoint.getDefaultDimensions(layer.name);
+          olLayer.setSource(
+            new WMTS({
+              layer: layer.name,
+              style: layer.defaultStyle || layer.styles[0].name,
+              matrixSet: matrixSet.identifier,
+              format: resourceUrl.format,
+              url: resourceUrl.url,
+              requestEncoding: resourceUrl.encoding,
+              referrerPolicy: layerModel.referrerPolicy,
+              tileGrid,
+              projection: matrixSet.crs,
+              dimensions,
+              attributions: layerModel.attributions,
+            }),
+          );
+        })
+        .then(() => emitLayerLoadingStatusSuccess(olLayer))
+        .catch((e) => {
+          const httpStatus =
+            e instanceof EndpointError ? e.httpStatus : undefined;
+          emitLayerLoadingError(olLayer, e, httpStatus);
+        });
+      layer = olLayer;
+      break;
+    }
+
+    case "wfs": {
+      const olLayer = new VectorLayer({
+        style: layerModel.style ?? defaultStyle,
+      });
+      new WfsEndpoint(layerModel.url)
+        .isReady()
+        .then((endpoint) => {
+          const featureType =
+            endpoint.getSingleFeatureTypeName() ?? layerModel.featureType;
+          olLayer.setSource(
+            new VectorSource({
+              format: new GeoJSON(),
+              url: function (extent) {
+                return endpoint.getFeatureUrl(featureType, {
+                  maxFeatures: WFS_MAX_FEATURES,
+                  asJson: true,
+                  outputCrs: "EPSG:3857",
+                  extent: extent as [number, number, number, number],
+                  extentCrs: "EPSG:3857",
+                });
+              },
+              strategy: bboxStrategy,
+              attributions: layerModel.attributions,
+            }),
+          );
+        })
+        .then(() => emitLayerLoadingStatusSuccess(olLayer))
+        .catch((e) => {
+          const httpStatus =
+            e instanceof EndpointError ? e.httpStatus : undefined;
+          emitLayerLoadingError(olLayer, e, httpStatus);
+        });
+      layer = olLayer;
+      break;
+    }
+
+    case "maplibre-style": {
+      layer = new MapboxVectorLayer({
+        styleUrl: layerModel.styleUrl,
+        accessToken: layerModel.accessToken,
+      }) as unknown as Layer;
+      defer().then(() => emitLayerLoadingStatusSuccess(layer));
+      break;
+    }
+
+    case "geojson": {
+      layer = new VectorLayer({
+        style: layerModel.style ?? defaultStyle,
+      });
+      let source: VectorSource;
+      if (layerModel.url !== undefined) {
+        source = new VectorSource({
+          format: new GeoJSON(),
+          url: layerModel.url,
+          attributions: layerModel.attributions,
+        });
+        source.once("featuresloadend", () =>
+          emitLayerLoadingStatusSuccess(layer),
+        );
+        source.once("featuresloaderror", () =>
+          emitLayerLoadingError(
+            layer,
+            new Error(
+              `GeoJSON features could not be loaded from: ${layerModel.url}`,
+            ),
+          ),
+        );
+      } else {
+        let geojson = layerModel.data;
+        try {
+          if (typeof geojson === "string") {
+            geojson = JSON.parse(geojson);
+          }
+          const features = GEOJSON.readFeatures(geojson, {
+            featureProjection: "EPSG:3857",
+            dataProjection: "EPSG:4326",
+          }) as Feature<Geometry>[];
+          source = new VectorSource({
+            features,
+            attributions: layerModel.attributions,
+          });
+          defer().then(() => emitLayerLoadingStatusSuccess(layer));
+        } catch (e) {
+          console.warn(
+            "GeoJSON layer data could not be parsed/read",
+            layerModel,
+            e,
+          );
+          source = new VectorSource({
+            features: [],
+            attributions: layerModel.attributions,
+          });
+          const err = e instanceof Error ? e : new Error(String(e));
+          defer().then(() => emitLayerLoadingError(layer, err));
+        }
+      }
+      layer.setSource(source);
+      break;
+    }
+
+    case "ogcapi": {
+      const ogcEndpoint = new OgcApiEndpoint(layerModel.url);
+      let layerUrl: string;
+      try {
+        if (layerModel.useTiles) {
+          if (layerModel.useTiles === "vector") {
+            layerUrl = await ogcEndpoint.getVectorTilesetUrl(
+              layerModel.collection,
+              layerModel.tileMatrixSet,
+            );
+            layer = new VectorTileLayer({
+              source: new OGCVectorTile({
+                url: layerUrl,
+                format: new MVT(),
+                attributions: layerModel.attributions,
+              }),
+            });
+          } else if (layerModel.useTiles === "map") {
+            layerUrl = await ogcEndpoint.getMapTilesetUrl(
+              layerModel.collection,
+              layerModel.tileMatrixSet,
+            );
+            layer = new TileLayer({
+              source: new OGCMapTile({
+                url: layerUrl,
+                attributions: layerModel.attributions,
+              }),
+            });
+          }
+        } else {
+          layerUrl = await ogcEndpoint.getCollectionItemsUrl(
+            layerModel.collection,
+            layerModel.options,
+          );
+          layer = new VectorLayer({
+            source: new VectorSource({
+              format: new GeoJSON(),
+              url: layerUrl,
+              attributions: layerModel.attributions,
+            }),
+            style: layerModel.style ?? defaultStyle,
+          });
+        }
+        defer().then(() => emitLayerLoadingStatusSuccess(layer));
+      } catch (e) {
+        if (layerModel.useTiles === "vector") {
+          layer = new VectorTileLayer({
+            properties: { [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true },
+          });
+        } else if (layerModel.useTiles === "map") {
+          layer = new TileLayer({
+            properties: { [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true },
+          });
+        } else {
+          layer = new VectorLayer({
+            style: layerModel.style ?? defaultStyle,
+            properties: { [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true },
+          });
+        }
+        const httpStatus =
+          e instanceof EndpointError ? e.httpStatus : undefined;
+        const err = e instanceof Error ? e : new Error(String(e));
+        defer().then(() => emitLayerLoadingError(layer, err, httpStatus));
+      }
+      break;
+    }
+
+    case "geotiff": {
+      const geoTiffSource = new GeoTIFF({
+        sources: [{ url: layerModel.url }],
+        convertToRGB: "auto",
+      });
+      layer = new WebGLTileLayer({
+        source: geoTiffSource,
+      });
+      // FIXME: actually track tile loading
+      defer().then(() => emitLayerLoadingStatusSuccess(layer));
+      break;
+    }
+
+    default: {
+      // we create an empty placeholder layer so that we still have a corresponding layer in OL
+      layer = new VectorLayer({
+        properties: {
+          [`${GEOSPATIAL_SDK_PREFIX}layer-with-error`]: true,
+        },
+      });
+      defer().then(() =>
+        emitLayerCreationError(
+          layer,
+          new Error(`Unrecognized layer type: ${JSON.stringify(layerModel)}`),
+        ),
+      );
+    }
+  }
+
+  updateLayerProperties(layerModel, layer!);
+
+  return layer!;
+}

--- a/packages/openlayers/lib/map/listen.test.ts
+++ b/packages/openlayers/lib/map/listen.test.ts
@@ -8,7 +8,7 @@ import { get as getProjection, toLonLat } from "ol/proj.js";
 import { FeaturesHoverEventType } from "@geospatial-sdk/core";
 import BaseEvent from "ol/events/Event.js";
 import { GEOSPATIAL_SDK_PREFIX } from "./constants.js";
-import { createLayer, resetMapFromContext } from "./create-map.js";
+import { resetMapFromContext } from "./create-map.js";
 import {
   MAP_CTX_LAYER_GEOJSON_FIXTURE,
   MAP_CTX_LAYER_WFS_FIXTURE,
@@ -22,6 +22,7 @@ import MapBrowserEvent from "ol/MapBrowserEvent.js";
 import BaseObject from "ol/Object.js";
 import Layer from "ol/layer/Layer.js";
 import { EndpointError } from "@camptocamp/ogc-client";
+import { createLayer } from "./layer-creation.js";
 
 vi.mock("./get-features.js", () => ({
   readFeaturesAtPixel() {


### PR DESCRIPTION
This PR uses an internal promise chain to make sure that no update to a map (OpenLayers or MapLibre) is lost because of quick successive updates with `applyContextDiffToMap`.

Now both `createMapFromContext` and `applyContextDiffToMap` retuyrn asynchronously. A new `getMapUpdatesPromise` function returns a promise that resolves when all updates have been applied.

This is a breaking change and I think we can make a 1.0.0 version